### PR TITLE
Filter attachments correctly by report option

### DIFF
--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -163,7 +163,8 @@ class SuperModel(BaseModel):
         ar_attachments = self.Attachment
         an_attachments = [a for a in itertools.chain(*map(
             lambda an: an.Attachment, self.Analyses))]
-        attachments = ar_attachments + an_attachments
+        attachments = filter(lambda a: a.getReportOption() == option,
+                             ar_attachments + an_attachments)
         return self.sort_attachments(attachments)
 
     def get_sorted_ar_attachments(self, option="r"):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR filters the AR/AN attachments correctly

## Current behavior before PR

Ignored attachments were rendered

## Desired behavior after PR is merged

Ignored attachments are ... ignored

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
