### PR TITLE
Fixed empty Date Published on Default report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ package-lock.json
 src/senaite.*
 yarn-error.log
 yarn.lock
+
+# vim editor
+*.swp

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ is **not** the recommended way, because with future updates of
 
 Therefore it is recommended to create a new
 [SENAITE Add-On Package](https://docs.plone.org/4/en/develop/addons/schema-driven-forms/creating-a-simple-form/creating-a-package.html)
-and put the custom reports in there.
+and put the custom reports in there. Note that the naming of the report template is important if you are customising a multi-sample report - you MUST start or end the template name with the word 'multi'.
 
 In your new package `configure.zcml` you have to specify the folder where your reports live:
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -2,6 +2,7 @@
 ------------------
 
 - #66: Fix Publication Preference Traceback with Default template
+- #68: Fix empty Date Published on Default report
 
 1.2.0 (2019-03-30)
 ------------------

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -331,7 +331,7 @@
           </tr>
           <tr>
             <td class="label" i18n:translate="">Date Published</td>
-            <td tal:content="python:view.to_localized_time(model.DatePublished)"></td>
+            <td tal:content="python:view.to_localized_time(model.DatePublished or view.timestamp)"></td>
           </tr>
           <tr tal:condition="reporter">
             <td class="label" i18n:translate="">Published by</td>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.impress/issues/68

## Current behavior before PR
Date Published is sometimes empty on default report

## Desired behavior after PR is merged
Set date published to current date time if empty

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
