### PR TITLE
Remove call to getObjectWorkflowStates

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.2.4 (unreleased)
 ------------------
 
+- #96 Remove call to getObjectWorkflowStates (in `is_provisional` func)
 - #91 Fix infinite recursion when calling print/publish view w/o items parameter
 - #89 PDF Print View
 - #88 Support context aware report controller views

--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -41,7 +41,7 @@ class SuperModel(BaseModel):
         if self.is_invalid():
             return True
         valid_states = ['verified', 'published']
-        return api.get_review_status(self.instance) in valid_states
+        return api.get_review_status(self.instance) not in valid_states
 
     def is_out_of_range(self, analysis):
         """Check if the analysis is out of range

--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -41,10 +41,7 @@ class SuperModel(BaseModel):
         if self.is_invalid():
             return True
         valid_states = ['verified', 'published']
-        states = self.getObjectWorkflowStates().values()
-        if not any(map(lambda s: s in valid_states, states)):
-            return True
-        return False
+        return api.get_review_status(self.instance) in valid_states
 
     def is_out_of_range(self, analysis):
         """Check if the analysis is out of range


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Compatibility with https://github.com/senaite/senaite.core/pull/1579

This Pull Request removes the call to `getObjectWorkflowStates`. This metadata column has been removed (and functions as well) from `senaite.core`. This metadata was used for when objects were bound to multiple workflows. This is not true since long time ago.

## Current behavior before PR

Impress reports use the function `is_provisional` to know if the report is provisional. This function is relying on `getObjectWorkflowStates`, that is no longer available.

## Desired behavior after PR is merged

`is_provisional` function directly relies on `api.get_workflow_status`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
