### PR TITLE
Fix Traceback for CCEmails rendering in publish view

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.0.0rc3 (unreleased)
 ---------------------
 
-- No changes yet
+- #101 Fix Traceback for CCEmails rendering in publish view
 
 
 2.0.0rc2 (2020-10-13)

--- a/src/senaite/impress/templates/publish.pt
+++ b/src/senaite/impress/templates/publish.pt
@@ -138,7 +138,9 @@
               </td>
               <!-- CC Emails -->
               <td>
-                <tal:ccemails repeat="ccemail python:model.CCEmails.split(',')">
+                <tal:ccemails define="ccemails model/CCEmails"
+                              condition="ccemails"
+                              repeat="ccemail python:model.CCEmails.split(',')">
                   <a href="#"
                      tal:attributes="href string:mailto:${ccemail}">
                     <div tal:content="ccemail" />


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a traceback that occurs for empty CCEmails

## Traceback
```
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.impress.publishview, line 95, in __call__
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 367, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 307, in render
  Module chameleon.template, line 214, in render
  Module chameleon.template, line 192, in render
  Module 51ed7a26bf10c8da6bb343541b82a273, line 1342, in render
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (model.CCEmails.split(','))
  Module <string>, line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'split'
```

## Current behavior before PR

Traceback occurs on publish

## Desired behavior after PR is merged

No Traceback occurs on publish

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
