### PR TITLE
Re-add custom JS snippet

### DIFF
--- a/src/senaite/impress/templates/publish.pt
+++ b/src/senaite/impress/templates/publish.pt
@@ -9,6 +9,14 @@
     <title i18n:translate="">SENAITE IMPRESS</title>
     <!-- SENAITE Impress HTML Head -->
     <div tal:replace="structure provider:senaite.impress.htmlhead" />
+    <!-- CUSTOM JS
+         N.B. we render the JS inline, because traversal seems to not work for plone:static resouces!
+    -->
+    <tal:custom_js repeat="script view/get_custom_javascripts">
+      <!-- <tal:t replace="script/filename"/> -->
+      <script type="text/javascript" tal:content="script/filecontents"></script>
+    </tal:custom_js>
+    <!-- /CUSTOM JS -->
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR re-adds the injection of custom JS to the publish template.

## Current behavior before PR

Custom JS were not loaded

## Desired behavior after PR is merged

Custom JS are loaded in the publish.pt template
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
