### PR TITLE
Fix remarks rendering in reports

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #103 Fix remarks rendering in reports
 - #101 Fix Traceback for CCEmails rendering in publish view
 
 

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -489,7 +489,7 @@
   </tal:render>
 
   <!-- QC RESULTS -->
-  <tal:render condition="python:True"
+  <tal:render condition="python:False"
               define="qcanalyses python:model.getQCAnalyses(['verified', 'published']);">
     <div class="row section-results no-gutters" tal:condition="qcanalyses">
       <div class="small">

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -10,6 +10,7 @@
           report_options python:options.get('report_options', {});
           attachments_per_row python:int(report_options.get('attachments_per_row', 2));
           attachments_per_row python:attachments_per_row<1 and 1 or attachments_per_row;
+          show_remarks python:bool(report_options.get('show_remarks', False));
           page_width options/page_width|nothing;
           page_height options/page_height|nothing;
           content_width options/content_width|nothing;
@@ -18,6 +19,20 @@
   <!-- Custom Report Controls -->
   <div id="controls" class="noprint">
     <div i18n:translate="" class="text-secondary mb-2">Custom Report Options</div>
+    <!-- Show Remarks -->
+    <div class="mb-3">
+      <div class="input-group">
+        <div class="custom-control custom-checkbox">
+          <input name="show_remarks" type="checkbox" class="custom-control-input" id="show-remarks">
+          <label class="custom-control-label" for="show-remarks">
+            Remarks
+          </label>
+        </div>
+      </div>
+      <small class="form-text text-muted" i18n:translate="">
+        Show Sample Remarks
+      </small>
+    </div>
     <!-- Attachments per row -->
     <div class="mb-3">
       <div class="input-group">
@@ -484,13 +499,23 @@
   </tal:render>
 
   <!-- REMARKS -->
-  <tal:render condition="python:True">
+  <tal:render condition="show_remarks">
     <div class="row section-remarks no-gutters"
           tal:define="remarks model/getRemarks"
           tal:condition="remarks">
-      <div class="">
+      <div class="remarks_history">
         <h2 i18n:translate>Remarks for <span tal:replace="model/getId"/></h2>
-        <div class="text-info" tal:content="structure remarks"></div>
+        <tal:record repeat="record remarks">
+          <div class="record" tal:attributes="id record/id;">
+            <div class="record-header border-bottom" tal:condition="record/user_id">
+              <span class="record-user" tal:content="record/user_id"/>
+              <span class="record-username" tal:content="record/user_name"/>
+              <span class="record-date" tal:content="record/created_ulocalized"/>
+            </div>
+            <div class="record-content"
+                  tal:content="structure record/html_content"></div>
+          </div>
+        </tal:record>
       </div>
     </div>
   </tal:render>

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -8,6 +8,7 @@
           report_options python:options.get('report_options', {});
           attachments_per_row python:int(report_options.get('attachments_per_row', 2));
           attachments_per_row python:attachments_per_row<1 and 1 or attachments_per_row;
+          show_remarks python:bool(report_options.get('show_remarks', False));
           page_width options/page_width|nothing;
           page_height options/page_height|nothing;
           content_width options/content_width|nothing;
@@ -16,6 +17,20 @@
   <!-- Custom Report Controls -->
   <div id="controls" class="noprint">
     <div i18n:translate="" class="text-secondary mb-2">Custom Report Options</div>
+    <!-- Show Remarks -->
+    <div class="mb-3">
+      <div class="input-group">
+        <div class="custom-control custom-checkbox">
+          <input name="show_remarks" type="checkbox" class="custom-control-input" id="show-remarks">
+          <label class="custom-control-label" for="show-remarks">
+            Remarks
+          </label>
+        </div>
+      </div>
+      <small class="form-text text-muted" i18n:translate="">
+        Show Sample Remarks
+      </small>
+    </div>
     <!-- Attachments per row -->
     <div class="mb-3">
       <div class="input-group">
@@ -507,14 +522,24 @@
   </tal:render>
 
   <!-- REMARKS -->
-  <tal:render condition="python:True">
+  <tal:render condition="show_remarks">
     <tal:model repeat="model collection">
       <div class="row section-remarks no-gutters"
            tal:define="remarks model/getRemarks"
            tal:condition="remarks">
-        <div class="">
+        <div class="remarks_history">
           <h2 i18n:translate>Remarks for <span tal:replace="model/getId"/></h2>
-          <div class="text-info" tal:content="structure remarks"></div>
+          <tal:record repeat="record remarks">
+            <div class="record" tal:attributes="id record/id;">
+              <div class="record-header border-bottom" tal:condition="record/user_id">
+                <span class="record-user" tal:content="record/user_id"/>
+                <span class="record-username" tal:content="record/user_name"/>
+                <span class="record-date" tal:content="record/created_ulocalized"/>
+              </div>
+              <div class="record-content"
+                   tal:content="structure record/html_content"></div>
+            </div>
+          </tal:record>
         </div>
       </div>
     </tal:model>

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -508,7 +508,7 @@
   </tal:render>
 
   <!-- QC RESULTS -->
-  <tal:render condition="python:True">
+  <tal:render condition="python:False">
     <tal:model repeat="model collection">
       <tal:qc define="qcanalyses python:model.getQCAnalyses(['verified', 'published']);">
         <div class="row section-results no-gutters" tal:condition="qcanalyses">

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -427,7 +427,7 @@
   </tal:render>
 
   <!-- QC RESULTS -->
-  <tal:render condition="python:True">
+  <tal:render condition="python:False">
     <tal:model repeat="model collection">
       <tal:qc define="qcanalyses python:model.getQCAnalyses(['verified', 'published']);">
         <div class="row section-results no-gutters" tal:condition="qcanalyses">

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -8,6 +8,7 @@
           report_options python:options.get('report_options', {});
           attachments_per_row python:int(report_options.get('attachments_per_row', 2));
           attachments_per_row python:attachments_per_row<1 and 1 or attachments_per_row;
+          show_remarks python:bool(report_options.get('show_remarks', False));
           page_width options/page_width|nothing;
           page_height options/page_height|nothing;
           content_width options/content_width|nothing;
@@ -16,6 +17,20 @@
   <!-- Custom Report Controls -->
   <div id="controls" class="noprint">
     <div i18n:translate="" class="text-secondary mb-2">Custom Report Options</div>
+    <!-- Show Remarks -->
+    <div class="mb-3">
+      <div class="input-group">
+        <div class="custom-control custom-checkbox">
+          <input name="show_remarks" type="checkbox" class="custom-control-input" id="show-remarks">
+          <label class="custom-control-label" for="show-remarks">
+            Remarks
+          </label>
+        </div>
+      </div>
+      <small class="form-text text-muted" i18n:translate="">
+        Show Sample Remarks
+      </small>
+    </div>
     <!-- Attachments per row -->
     <div class="mb-3">
       <div class="input-group">
@@ -428,14 +443,24 @@
   </tal:render>
 
   <!-- REMARKS -->
-  <tal:render condition="python:True">
+  <tal:render condition="show_remarks">
     <tal:model repeat="model collection">
       <div class="row section-remarks no-gutters"
            tal:define="remarks model/getRemarks"
            tal:condition="remarks">
-        <div class="">
+        <div class="remarks_history">
           <h2 i18n:translate>Remarks for <span tal:replace="model/getId"/></h2>
-          <div class="text-info" tal:content="structure remarks"></div>
+          <tal:record repeat="record remarks">
+            <div class="record" tal:attributes="id record/id;">
+              <div class="record-header border-bottom" tal:condition="record/user_id">
+                <span class="record-user" tal:content="record/user_id"/>
+                <span class="record-username" tal:content="record/user_name"/>
+                <span class="record-date" tal:content="record/created_ulocalized"/>
+              </div>
+              <div class="record-content"
+                   tal:content="structure record/html_content"></div>
+            </div>
+          </tal:record>
         </div>
       </div>
     </tal:model>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.impress/issues/99

## Current behavior before PR

- Remarks rendered as raw records structure
- UnicodeDecode Error when the remarks content contains unicode chars (`Error: 'ascii' codec can't decode byte 0xc3 in position 64: ordinal not in range(128)`)

## Desired behavior after PR is merged

- Remarks rendered similar as in samples
- Unicode chars handled correctly


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
