### PR TITLE
Compatibility with core#1717

### DIFF
--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -342,7 +342,7 @@
           </tr>
           <tr>
             <td class="label" i18n:translate="">Date Verified</td>
-            <td tal:content="python:view.to_localized_time(model.get_transition_date('bika_ar_workflow', 'verified'))"></td>
+            <td tal:content="python:view.to_localized_time(model.getDateVerified())"></td>
           </tr>
           <tr>
             <td class="label" i18n:translate="">Date Published</td>

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -353,7 +353,7 @@
           </tr>
           <tr>
             <td class="label" i18n:translate="">Date Verified</td>
-            <td tal:content="python:view.to_localized_time(model.get_transition_date('bika_ar_workflow', 'verified'))"></td>
+            <td tal:content="python:view.to_localized_time(model.getDateVerified())"></td>
           </tr>
           <tr>
             <td class="label" i18n:translate="">Date Published</td>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Requests makes senaite.impress compatible with https://github.com/senaite/senaite.core/pull/1717

## Current behavior before PR

Default and Multidefault reports depend on `bika_ar_workflow` for the rendering of sample's verification date

## Desired behavior after PR is merged

Default and Multidefault reports do not depend on `bika_ar_workflow` for the rendering of sample's verification date

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
