### PR TITLE
Fix duplicate metadata in single reports

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.0.0 (unreleased)
 ------------------
 
-- no changes yet
+- #108 Fix duplicate metadata in single reports
 
 
 2.0.0rc3 (2021-01-04)

--- a/src/senaite/impress/ajax.py
+++ b/src/senaite/impress/ajax.py
@@ -237,6 +237,9 @@ class AjaxPublishView(PublishView):
         # get the selected orientation
         orientation = data.get("orientation", "portrait")
 
+        # get a timestamp
+        timestamp = DateTime().ISO8601()
+
         # Generate the print CSS with the set format/orientation
         css = self.get_print_css(
             paperformat=paperformat, orientation=orientation)
@@ -259,20 +262,21 @@ class AjaxPublishView(PublishView):
         report_uids = map(
             lambda report: report.get("uids", "").split(","), html_reports)
 
-        # prepare some metadata
-        metadata = {
-            "template": template,
-            "paperformat": paperformat,
-            "orientation": orientation,
-            "timestamp": DateTime().ISO8601(),
-        }
-
         # get the storage multi-adapter to save the generated PDFs
         storage = getMultiAdapter(
             (self.context, self.request), IPdfReportStorage)
 
         report_groups = []
         for pdf, html, uids in zip(pdf_reports, html_reports, report_uids):
+            # prepare some metadata
+            # NOTE: We are doing it in the loop to ensure a new dictionary is
+            #       created for each report.
+            metadata = {
+                "template": template,
+                "paperformat": paperformat,
+                "orientation": orientation,
+                "timestamp": timestamp,
+            }
             # ensure we have valid UIDs here
             uids = filter(api.is_uid, uids)
             # convert the bs4.Tag back to pure HTML


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes duplicate metadata when publishing mulitple single reports at once

## Current behavior before PR

The "contained requests" metadata was always set to the UID of the last published report,
because the metadata dictionary was passed by reference for each report.

## Desired behavior after PR is merged

A new metadata dictionary is created for each report with the correct contained sample UID inside

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
