### PR TITLE
Pin beautifulsoup4 to version 4.3.9

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.0.1 (unreleased)
 ------------------
 
+- Pin Beautiful Soup version to 4.9.3
 
 
 2.0.0 (2021-07-26)

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.0.1 (unreleased)
 ------------------
 
-- Pin Beautiful Soup version to 4.9.3
+- #111 Pin Beautiful Soup version to 4.9.3 to support Python2
 
 
 2.0.0 (2021-07-26)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         "setuptools",
         # The final version of Beautiful Soup to support Python 2 was 4.9.3.
-        "beautifulsoup4==4.3.9",
+        "beautifulsoup4==4.9.3",
         "CairoSVG==1.0.20",
         "cairocffi<1.0.0",
         # Python 2.x is not supported by WeasyPrint v43

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(
     zip_safe=False,
     install_requires=[
         "setuptools",
-        "beautifulsoup4",
+        # The final version of Beautiful Soup to support Python 2 was 4.9.3.
+        "beautifulsoup4==4.3.9",
         "CairoSVG==1.0.20",
         "cairocffi<1.0.0",
         # Python 2.x is not supported by WeasyPrint v43


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The final version of Beautiful Soup to support Python 2 was 4.9.3.

## Current behavior before PR

Build fails

## Desired behavior after PR is merged

Build succeeds

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
