### PR TITLE
Fix Beautiful soup v4.9.3 misspeling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         "setuptools",
         # The final version of Beautiful Soup to support Python 2 was 4.9.3.
-        "beautifulsoup4==4.3.9",
+        "beautifulsoup4==4.9.3",
         "CairoSVG==1.0.20",
         "cairocffi<1.0.0",
         # Python 2.x is not supported by WeasyPrint v43


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The last version of beautifulsoup4 that is compatible with Python2.7 was misspelled

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
