### PR TITLE
Pin Pyphen to version 0.11.0

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.0.1 (unreleased)
 ------------------
 
+- #114 Pin pyphen to version 0.11.0 to support Python2
 - #111 Pin Beautiful Soup version to 4.9.3 to support Python2
 
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
         "tinycss2<1.0.0",
         # cssselect2 0.3.0 does not support Python 2.x anymore
         "cssselect2<0.3.0",
+        # pyphen 0.12.0 does not support Python 2.x anymore
+        "pyphen==0.11.0",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR pins pyphen to version 0.11.0

## Current behavior before PR

Version `0.12.0` was fetched, which is not compatible with Python 2.x anymore

## Desired behavior after PR is merged

Version `0.11.0` is fetched

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
