### PR TITLE
ISO17025: Added method title to reports

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.2.0 (unreleased)
 ------------------
 
-- no changes yet
+- #115 ISO17025: Added method title to reports
 
 
 2.1.0 (2022-01-05)

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -81,6 +81,7 @@
      .report .section-header h1 { font-size: 175%; }
      .report .section-header img.logo { height: 35px; margin: 20px 0; }
      .report .barcode-hri { margin-top: -0.25em; font-size: 8pt; }
+     .report .section-results .methodtitle { font-size: 85%; }
      .report .section-footer table td { border: none; }
      .report .section-footer {
        position: fixed;
@@ -430,6 +431,11 @@
                       <span tal:condition="analysis/ScientificName">
                         <span class="font-italic" tal:content="analysis/title"></span>
                       </span>
+                      <!-- Method -->
+                      <div class="text-secondary methodtitle"
+                           i18n:translate=""
+                           tal:define="method_title python:analysis and analysis.getMethodTitle() or '';"
+                           tal:content="structure python:view.hyphenize(method_title)"/>
                     </td>
                     <td class="text-right">
                       <span class="result" tal:content="structure python:model.get_formatted_result(analysis)">23</span>

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -79,6 +79,7 @@
      .report .section-header h1 { font-size: 175%; }
      .report .section-header img.logo { height: 35px; margin: 20px 0; }
      .report .barcode-hri { margin-top: -0.25em; font-size: 8pt; }
+     .report .section-results .methodtitle { font-size: 85%; }
      .report .section-footer table td { border: none; }
      .report .section-footer {
        position: fixed;
@@ -444,6 +445,11 @@
                         <span tal:condition="analysis/ScientificName">
                           <span class="font-italic" tal:content="analysis/title"></span>
                         </span>
+                        <!-- Method -->
+                        <div class="text-secondary methodtitle"
+                             i18n:translate=""
+                             tal:define="method_title python:analysis and analysis.getMethodTitle() or '';"
+                             tal:content="structure python:view.hyphenize(method_title)"/>
                       </td>
                       <td class="text-right">
                         <span class="result" tal:content="structure python:model.get_formatted_result(analysis)">23</span>

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -367,10 +367,16 @@
                 </tr>
                 <tr tal:define="analyses python:view.get_analyses_by(collection, poc=poc, category=category);
                                 analyses_by_title python:map(lambda a: a.Title(), analyses);
+                                methods_by_title python:dict(zip(analyses_by_title, map(lambda a: a.getMethodTitle(), analyses)));
                                 analyses_titles python:view.uniquify_items(analyses_by_title)"
                     tal:repeat="analysis_title python:analyses_titles">
                   <td class="text-secondary">
                     <span tal:content="analysis_title"/>
+                    <!-- Method -->
+                    <div class="text-secondary methodtitle"
+                         i18n:translate=""
+                         tal:define="method_title python:methods_by_title.get(analysis_title, '');"
+                         tal:content="structure python:view.hyphenize(method_title)"/>
                   </td>
                   <tal:results repeat="model collection">
                     <tal:analyses tal:define="analyses python:view.get_analyses_by(model, title=analysis_title);">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the method title below the analyses in the default reports to be ISO17025 compliant.

## Current behavior before PR

No method title displayed in report

## Desired behavior after PR is merged

Method title is displayed below each analysis

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
