### PR TITLE
Allow to filter selectable impress templates

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.2.0 (unreleased)
 ------------------
 
+- #117 Allow to filter selectable impress templates
 - #115 ISO17025: Added method title to reports
 
 

--- a/src/senaite/impress/controlpanel.py
+++ b/src/senaite/impress/controlpanel.py
@@ -22,13 +22,35 @@ from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
 from plone.app.registry.browser.controlpanel import RegistryEditForm
 from plone.z3cform import layout
 from senaite.impress import senaiteMessageFactory as _
+from senaite.impress.interfaces import ITemplateFinder
 from zope import schema
+from zope.component import getUtility
 from zope.interface import Interface
+from zope.interface import provider
+from zope.schema.interfaces import IContextAwareDefaultFactory
+
+
+@provider(IContextAwareDefaultFactory)
+def default_templates(context):
+    finder = getUtility(ITemplateFinder)
+    templates = finder.get_templates()
+    return [t[0] for t in templates]
 
 
 class IImpressControlPanel(Interface):
     """Controlpanel Settings
     """
+
+    templates = schema.List(
+        title=_(u"Available Templates"),
+        description=_("Please choose the templates that can be selected"),
+        required=True,
+        defaultFactory=default_templates,
+        value_type=schema.Choice(
+            title=_(u"Active templates"),
+            source="senaite.impress.vocabularies.Templates",
+        )
+    )
 
     default_template = schema.Choice(
         title=_(u"Default Template"),

--- a/src/senaite/impress/profiles/default/metadata.xml
+++ b/src/senaite/impress/profiles/default/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-  <version>2000</version>
+  <version>2.2.0</version>
 </metadata>

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -325,12 +325,12 @@ class PublishView(BrowserView):
         # Todo: Implement cascading lookup: client->registry->config
         return PAPERFORMATS
 
-    def get_report_templates(self, extensions=[".pt", ".html"]):
-        """Returns a sorted list of template/path pairs
+    def get_report_templates(self):
+        """Returns selected templates
         """
-        finder = getUtility(ITemplateFinder)
-        templates = finder.get_templates(extensions=extensions)
-        return sorted(map(lambda item: item[0], templates))
+        templates = api.get_registry_record(
+            "senaite.impress.templates")
+        return templates or []
 
     def get_default_template(self, default="senaite.lims:Default.pt"):
         """Returns the configured default template from the registry

--- a/src/senaite/impress/upgrades/configure.zcml
+++ b/src/senaite/impress/upgrades/configure.zcml
@@ -5,29 +5,11 @@
 
   <genericsetup:upgradeStep
       title="Upgrade SENAITE IMPRESS"
-      description=""
-      sortkey="3"
-      source="1200"
-      destination="2000"
-      handler="senaite.impress.upgrades.handlers.to_2000"
-      profile="senaite.impress:default" />
-
-  <genericsetup:upgradeStep
-      title="Upgrade SENAITE IMPRESS"
-      description="Initial Profile"
-      sortkey="2"
-      source="1000"
-      destination="1200"
-      handler="senaite.impress.upgrades.handlers.to_1200"
-      profile="senaite.impress:default" />
-
-  <genericsetup:upgradeStep
-      title="Upgrade SENAITE IMPRESS"
-      description="Initial Profile"
+      description="Upgrade to version 2.2.0"
       sortkey="1"
       source="*"
-      destination="1000"
-      handler="senaite.impress.upgrades.handlers.to_1000"
+      destination="2.2.0"
+      handler="senaite.impress.upgrades.handlers.run_all_importsteps"
       profile="senaite.impress:default" />
 
 </configure>

--- a/src/senaite/impress/upgrades/handlers.py
+++ b/src/senaite/impress/upgrades/handlers.py
@@ -23,30 +23,8 @@ from senaite.impress import logger
 PROFILE_ID = "profile-senaite.impress:default"
 
 
-def to_2000(portal_setup):
-    """Migration from version 1200 -> 2000
-
-    :param portal_setup: The portal_setup tool
-    """
-
-    logger.info("Run all import steps from SENAITE IMPRESS ...")
-    portal_setup.runAllImportStepsFromProfile(PROFILE_ID)
-    logger.info("Run all import steps from SENAITE IMPRESS [DONE]")
-
-
-def to_1200(portal_setup):
-    """Migration from version 1000 -> 1200
-
-    :param portal_setup: The portal_setup tool
-    """
-
-    logger.info("Run all import steps from SENAITE IMPRESS ...")
-    portal_setup.runAllImportStepsFromProfile(PROFILE_ID)
-    logger.info("Run all import steps from SENAITE IMPRESS [DONE]")
-
-
-def to_1000(portal_setup):
-    """Initial version to 1000
+def run_all_importsteps(portal_setup):
+    """Run all import steps
 
     :param portal_setup: The portal_setup tool
     """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds a new configuration option to choose the templates that can be selected in impress.

<img width="1126" alt="SENAITE LIMS 2022-02-04 14-26-19" src="https://user-images.githubusercontent.com/713193/152536821-7dcc175c-980c-413f-9bf5-8d6cc066c345.png">


## Current behavior before PR

Always the full list of available templates were rendered

## Desired behavior after PR is merged

Only the selected templates are displayed

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
