### PR TITLE
Fix offsets when localizing time

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.2.0 (unreleased)
 ------------------
 
+- #118 Fix offsets when localizing time
 - #117 Allow to filter selectable impress templates
 - #115 ISO17025: Added method title to reports
 

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -27,16 +27,16 @@ from string import Template
 
 import DateTime
 from bika.lims import POINTS_OF_CAPTURE
+from bika.lims import api
 from bika.lims.interfaces import IInternalUse
 from bika.lims.workflow import getTransitionDate
 from Products.CMFPlone.i18nl10n import ulocalized_time
 from Products.CMFPlone.utils import safe_unicode
-from bika.lims import api
 from senaite.app.supermodel.interfaces import ISuperModel
+from senaite.core.api import dtime
 from senaite.impress import logger
 from senaite.impress.decorators import returns_super_model
 from senaite.impress.reportview import ReportView as Base
-
 
 SINGLE_TEMPLATE = Template("""<!-- Single Report -->
 <div class="report" uids="${uids}" client_uid="${client_uid}">
@@ -113,6 +113,15 @@ class ReportView(Base):
         """
         if date is None:
             return ""
+        if dtime.is_DT(date):
+            # this interestingly fixes time offsets, e.g.:
+            # >>> time
+            # DateTime('2022/02/10 19:46:45.394387 GMT-1')
+            # >>> time.strftime("%H")
+            # '17'
+            # >>> DateTime(time.ISO()).strftime("%H")
+            # '19'
+            date = date.ISO()
         # default options
         options = {
             "long_format": True,

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -113,15 +113,12 @@ class ReportView(Base):
         """
         if date is None:
             return ""
+
         if dtime.is_DT(date):
-            # this interestingly fixes time offsets, e.g.:
-            # >>> time
-            # DateTime('2022/02/10 19:46:45.394387 GMT-1')
-            # >>> time.strftime("%H")
-            # '17'
-            # >>> DateTime(time.ISO()).strftime("%H")
-            # '19'
+            # this is a work around for time offsets!
+            # https://github.com/senaite/senaite.impress/pull/118
             date = date.ISO()
+
         # default options
         options = {
             "long_format": True,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR works around a time offset issue that happens when using `ulocalized_time` from `Products.CMFPlone.i18nl10n`

## Current behavior before PR

Code says more than 1000 words:

```
(Pdb++) date
DateTime('2022/02/10 19:46:45.394387 GMT-1')
(Pdb++) self.to_localized_time(date, long_format=1)
u'10.02.2022 17:46'
(Pdb++) self.to_localized_time(date.ISO(), long_format=1)
u'10.02.2022 19:46'
```

## Desired behavior after PR is merged

the ISO format of the `DateTime` object is used to work around the described issue

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
