### PR TITLE
Simplified report creation API

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.2.0 (unreleased)
 ------------------
 
+- #119 Simplified report creation API
 - #117 Allow to filter selectable impress templates
 - #115 ISO17025: Added method title to reports
 

--- a/src/senaite/impress/ajax.py
+++ b/src/senaite/impress/ajax.py
@@ -29,6 +29,7 @@ from senaite.impress import logger
 from senaite.impress.decorators import returns_json
 from senaite.impress.decorators import timeit
 from senaite.impress.interfaces import IPdfReportStorage
+from senaite.impress.interfaces import IReportWrapper
 from senaite.impress.publishview import PublishView
 from zope.component import getMultiAdapter
 from zope.interface import implements
@@ -216,7 +217,7 @@ class AjaxPublishView(PublishView):
         orientation = data.get("orientation", "portrait")
 
         # get a timestamp
-        timestamp = DateTime().ISO8601()
+        timestamp = DateTime().ISO()
 
         # Generate the print CSS with the set format/orientation
         css = self.get_print_css(
@@ -232,9 +233,6 @@ class AjaxPublishView(PublishView):
         # NOTE: each report is an instance of <bs4.Tag>
         html_reports = publisher.parse_reports(html)
 
-        # generate a PDF for each HTML report
-        pdf_reports = map(publisher.write_pdf, html_reports)
-
         # extract the UIDs of each HTML report
         # NOTE: UIDs are injected in `.analysisrequest.reportview.render`
         report_uids = map(
@@ -245,24 +243,25 @@ class AjaxPublishView(PublishView):
             (self.context, self.request), IPdfReportStorage)
 
         report_groups = []
-        for pdf, html, uids in zip(pdf_reports, html_reports, report_uids):
-            # prepare some metadata
-            # NOTE: We are doing it in the loop to ensure a new dictionary is
-            #       created for each report.
-            metadata = {
-                "template": template,
-                "paperformat": paperformat,
-                "orientation": orientation,
-                "timestamp": timestamp,
-            }
+        for html, uids in zip(html_reports, report_uids):
             # ensure we have valid UIDs here
             uids = filter(api.is_uid, uids)
             # convert the bs4.Tag back to pure HTML
             html = publisher.to_html(html)
+            # wrap the report
+            report = getMultiAdapter((html,
+                                      map(self.to_model, uids),
+                                      template,
+                                      paperformat,
+                                      orientation,
+                                      None,
+                                      publisher), interface=IReportWrapper)
+
             # BBB: inject contained UIDs into metadata
-            metadata["contained_requests"] = uids
+            metadata = report.get_metadata(
+                contained_requests=uids, timestamp=timestamp)
             # store the report(s)
-            objs = storage.store(pdf, html, uids, metadata=metadata)
+            objs = storage.store(report.pdf, html, uids, metadata=metadata)
             # append the generated reports to the list
             report_groups.append(objs)
 

--- a/src/senaite/impress/configure.zcml
+++ b/src/senaite/impress/configure.zcml
@@ -100,6 +100,11 @@
       factory="senaite.impress.publisher.Publisher"
       />
 
+  <!-- Report wrapper -->
+  <adapter
+      for="* * * * * * *"
+      factory="senaite.impress.reportwrapper.ReportWrapper" />
+
   <!-- Template Finder Utility -->
   <utility
       provides="senaite.impress.interfaces.ITemplateFinder"

--- a/src/senaite/impress/interfaces.py
+++ b/src/senaite/impress/interfaces.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims.interfaces import IBikaLIMS
+from zope.interface import Attribute
 from zope.interface import Interface
 from zope.viewlet.interfaces import IViewletManager
 
@@ -71,3 +72,11 @@ class IPdfReportStorage(Interface):
         """Stores the generated PDF for the given UIDs in a location and
         returns a list of generated report objects.
         """
+
+
+class IReportWrapper(Interface):
+    """Wrapper class for reports
+    """
+    pdf = Attribute("PDF data")
+    png = Attribute("PNG image data")
+    metadata = Attribute("Report metadata")

--- a/src/senaite/impress/interfaces.py
+++ b/src/senaite/impress/interfaces.py
@@ -78,5 +78,4 @@ class IReportWrapper(Interface):
     """Wrapper class for reports
     """
     pdf = Attribute("PDF data")
-    png = Attribute("PNG image data")
     metadata = Attribute("Report metadata")

--- a/src/senaite/impress/interfaces.py
+++ b/src/senaite/impress/interfaces.py
@@ -77,5 +77,8 @@ class IPdfReportStorage(Interface):
 class IReportWrapper(Interface):
     """Wrapper class for reports
     """
-    pdf = Attribute("PDF data")
-    metadata = Attribute("Report metadata")
+    pdf = Attribute("Generate PDF data")
+
+    def get_metadata(**kw):
+        """Generate metadata for the report
+        """

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -97,7 +97,7 @@ class PublishView(BrowserView):
         return self.template()
 
     def download(self):
-        """Generate PDF and send it fot download
+        """Generate PDF and send it for download
         """
         form = self.request.form
         # This is the html after it was rendered by the client browser and

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -39,6 +39,7 @@ from senaite.impress.interfaces import IMultiReportView
 from senaite.impress.interfaces import IPublisher
 from senaite.impress.interfaces import IPublishView
 from senaite.impress.interfaces import IReportView
+from senaite.impress.interfaces import IReportWrapper
 from senaite.impress.interfaces import ITemplateFinder
 from zope.component import ComponentLookupError
 from zope.component import getAdapter
@@ -96,6 +97,85 @@ class PublishView(BrowserView):
         if self.request.form.get("download", False):
             return self.download()
         return self.template()
+
+    def generate_reports_for(self,
+                             uids,
+                             group_by=None,
+                             template=None,
+                             paperformat=None,
+                             orientation=None,
+                             report_options=None):
+        """Generate reports for the given UIDs
+
+        :param uids: List of object UIDs to generate reports for
+        :param group_by: Grouping attribute/callable, e.g. getClientUID
+        :param template: Template, e.g. `senaite.impress:Default.pt`
+        :param paperformat: Paperformat, e.g. A4
+        :param orientation: Orientation, e.g. horizontal
+        :param report_options: Dictionary with custom report options
+
+        If any of the keyword arguments is not set, the default value of the
+        registry is used.
+
+        :returns: List of `IReportWrapper` objects
+        """
+        if template is None:
+            template = self.get_default_template()
+        report_template = self.get_report_template(template)
+
+        if paperformat is None:
+            paperformat = self.get_default_paperformat()
+
+        if orientation is None:
+            orientation = self.get_default_orientation()
+
+        if report_options is None:
+            report_options = {}
+
+        collection = self.get_collection(uids)
+        group_key = group_by if group_by else "_nogroup_"
+        grouped_collection = self.group_items_by(group_key, collection)
+        is_multi_template = self.is_multi_template(report_template)
+
+        htmls = []
+
+        for key, collection in grouped_collection.items():
+            # render multi report
+            if is_multi_template:
+                html = self.render_multi_report(collection,
+                                                report_template,
+                                                paperformat=paperformat,
+                                                orientation=orientation,
+                                                report_options=report_options)
+                htmls.append(html)
+            else:
+                # render single report
+                for model in collection:
+                    html = self.render_report(model,
+                                              report_template,
+                                              paperformat=paperformat,
+                                              orientation=orientation,
+                                              report_options=report_options)
+                    htmls.append(html)
+
+        # generate a PDF for each HTML report
+        publisher = self.publisher
+        report_css = self.get_print_css(
+            paperformat=paperformat, orientation=orientation)
+        publisher.add_inline_css(report_css)
+
+        # wrap the reports for further processing
+        reports = []
+        for html, collection in zip(htmls, grouped_collection.values()):
+            report = getMultiAdapter((html,
+                                      collection,
+                                      template,
+                                      paperformat,
+                                      orientation,
+                                      report_options,
+                                      publisher), interface=IReportWrapper)
+            reports.append(report)
+        return reports
 
     def download(self):
         """Generate PDF and send it for download

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -436,7 +436,7 @@ class PublishView(BrowserView):
             raise TypeError("Items must be iterable")
         results = OrderedDict()
         for item in items:
-            group_key = item.get(key)
+            group_key = item.get(key, key)
             if callable(group_key):
                 group_key = group_key()
             if group_key in results:

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -25,6 +25,8 @@ from functools import reduce
 from string import Template
 
 from bika.lims import api
+from bika.lims.permissions import ManageBika
+from bika.lims.permissions import TransitionPublishResults
 from plone.app.i18n.locales.browser.selector import LanguageSelector
 from plone.resource.utils import iterDirectoriesOfType
 from Products.Five import BrowserView
@@ -158,15 +160,13 @@ class PublishView(BrowserView):
     def is_manager(self):
         """Checks if the current user has manager rights
         """
-        from bika.lims.permissions import ManageBika
         roles = api.get_roles_for_permission(ManageBika, self.context)
         return self.user.has_role(roles)
 
     def is_publisher(self):
         """Checks if the current user has publisher rights
         """
-        from bika.lims.permissions import Publish
-        roles = api.get_roles_for_permission(Publish, self.context)
+        roles = api.get_roles_for_permission(TransitionPublishResults, self.context)
         return self.user.has_role(roles)
 
     def get_uids(self):

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -19,10 +19,11 @@
 # Some rights reserved, see README and LICENSE.
 
 import os
-from collections import Iterable
 from collections import OrderedDict
 from functools import reduce
 from string import Template
+
+from six.moves.collections_abc import Iterable
 
 from bika.lims import api
 from bika.lims.permissions import ManageBika

--- a/src/senaite/impress/reportwrapper.py
+++ b/src/senaite/impress/reportwrapper.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from DateTime import DateTime
+from senaite.impress.interfaces import IReportWrapper
+from zope.interface import implementer
+
+
+@implementer(IReportWrapper)
+class ReportWrapper(object):
+    """Report wrapper to generate PDF/PNG
+    """
+    def __init__(self,
+                 html,
+                 collection,
+                 template,
+                 paperformat,
+                 orientation,
+                 report_options,
+                 publisher):
+
+        self._pdf = None
+        self.html = html
+        self.collection = collection
+        self.template = template
+        self.paperformat = paperformat
+        self.orientation = orientation
+        self.report_options = report_options
+        self.publisher = publisher
+        self.created = DateTime()
+
+    @property
+    def pdf(self):
+        """Returns or generates the PDF on the fly
+        """
+        if self._pdf is None:
+            self._pdf = self.publisher.write_pdf(self.html)
+        return self._pdf
+
+    @property
+    def metadata(self):
+        """Returns the report metadata as a dictionary
+        """
+        return {
+            "template": self.template,
+            "paperformat": self.paperformat,
+            "orientation": self.orientation,
+            "timestamp": self.created.ISO(),
+        }
+
+    def __repr__(self):
+        return "<ReportWrapper for %s>" % ",".join(map(api.get_id, self.collection))

--- a/src/senaite/impress/reportwrapper.py
+++ b/src/senaite/impress/reportwrapper.py
@@ -37,16 +37,27 @@ class ReportWrapper(object):
             self._pdf = self.publisher.write_pdf(self.html)
         return self._pdf
 
-    @property
-    def metadata(self):
+    def get_metadata(self, **kw):
         """Returns the report metadata as a dictionary
         """
-        return {
+        metadata = {
             "template": self.template,
             "paperformat": self.paperformat,
             "orientation": self.orientation,
             "timestamp": self.created.ISO(),
         }
+        metadata.update(kw)
+        return metadata
+
+    def get_uids(self):
+        """Returns the UIDs of the collection
+        """
+        return list(map(api.get_uid, self.collection))
+
+    def get_ids(self):
+        """Returns the IDs of the collection
+        """
+        return list(map(api.get_id, self.collection))
 
     def __repr__(self):
-        return "<ReportWrapper for %s>" % ",".join(map(api.get_id, self.collection))
+        return "<ReportWrapper for %s>" % ",".join(self.get_ids())

--- a/src/senaite/impress/reportwrapper.py
+++ b/src/senaite/impress/reportwrapper.py
@@ -8,7 +8,7 @@ from zope.interface import implementer
 
 @implementer(IReportWrapper)
 class ReportWrapper(object):
-    """Report wrapper to generate PDF/PNG
+    """Report wrapper to generate PDF
     """
     def __init__(self,
                  html,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR simplifies the report creation API to allow direct report generation/publication from external Add-ons.

## Current behavior before PR

PDF reports were generated in an Ajax endpoint

## Desired behavior after PR is merged

PDF reports can be created using the `PublishView`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
