### PR TITLE
Pin pyphen version to 0.11.0 to support Python2 (1.x)

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -40,10 +40,10 @@ auto-checkout = *
 develop = .
 
 [sources]
-senaite.core = git git://github.com/senaite/senaite.core.git pushurl=git@github.com:senaite/senaite.core.git branch=1.3.x
-senaite.core.listing = git git://github.com/senaite/senaite.core.listing.git pushurl=git@github.com:senaite/senaite.core.listing.git branch=1.x
-senaite.core.supermodel = git git://github.com/senaite/senaite.core.supermodel.git pushurl=git@github.com:senaite/senaite.core.supermodel.git branch=1.x
-senaite.lims = git git://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=1.x
+senaite.core = git https://github.com/senaite/senaite.core.git pushurl=git@github.com:senaite/senaite.core.git branch=1.3.x
+senaite.core.listing = git https://github.com/senaite/senaite.core.listing.git pushurl=git@github.com:senaite/senaite.core.listing.git branch=1.x
+senaite.core.supermodel = git https://github.com/senaite/senaite.core.supermodel.git pushurl=git@github.com:senaite/senaite.core.supermodel.git branch=1.x
+senaite.lims = git https://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=1.x
 
 [lxml]
 recipe = z3c.recipe.staticlxml

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.2.6 (unreleased)
 ------------------
 
+- #122 Pin pyphen version to 0.11.0 to support Python2
 - #112 Pin Beautiful Soup version to 4.9.3 to support Python2
 
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
         "tinycss2<1.0.0",
         # cssselect2 0.3.0 does not support Python 2.x anymore
         "cssselect2<0.3.0",
+        # pyphen 0.12.0 does not support Python 2.x anymore
+        "pyphen==0.11.0",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request pins the version of pyphen to v0.11.0

## Current behavior before PR

```
Getting distribution for 'Pyphen>=0.8'.

error: Couldn't find a setup script in /tmp/tmpOgWrO6get_dist/pyphen-0.12.0.tar.gz

An error occurred when trying to install /tmp/tmpOgWrO6get_dist/pyphen-0.12.0.tar.gz. Look above this message for any errors that were output by easy_install.

While:

  Installing instance.

  Getting distribution for 'Pyphen>=0.8'.
```

## Desired behavior after PR is merged

Product is installed w/o problems

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
