### PR TITLE
Only one results report is generated when SingleReport template is selected

### DIFF
--- a/src/senaite/impress/ajax.py
+++ b/src/senaite/impress/ajax.py
@@ -23,6 +23,7 @@ import json
 
 from bika.lims import _
 from bika.lims import api
+from collections import OrderedDict
 from DateTime import DateTime
 from senaite.app.supermodel import SuperModel
 from senaite.impress import logger
@@ -274,7 +275,17 @@ class AjaxPublishView(PublishView):
         if not exit_urls:
             return api.get_url(self.context)
 
-        return exit_urls[0]
+        # Group the urls by path. This makes possible to at least return a
+        # single url for multiple uids when the base path (e.g. client) is the
+        # same. This is required for Single Reports, for which there are as many
+        # report groups as samples, regardless of clients
+        import pdb;pdb.set_trace()
+        groups = OrderedDict()
+        for url in exit_urls:
+            base_path, uids = url.split("?uids=")
+            path_uids = groups.get(base_path, "")
+            groups[base_path] = ",".join(filter(None, [path_uids, uids]))
+        return "?uids=".join(groups.items()[0])
 
     def get_exit_url_for(self, reports, action="save"):
         """Handle the response for the generated reports

--- a/src/senaite/impress/ajax.py
+++ b/src/senaite/impress/ajax.py
@@ -279,7 +279,6 @@ class AjaxPublishView(PublishView):
         # single url for multiple uids when the base path (e.g. client) is the
         # same. This is required for Single Reports, for which there are as many
         # report groups as samples, regardless of clients
-        import pdb;pdb.set_trace()
         groups = OrderedDict()
         for url in exit_urls:
             base_path, uids = url.split("?uids=")

--- a/src/senaite/impress/ajax.py
+++ b/src/senaite/impress/ajax.py
@@ -319,9 +319,10 @@ class AjaxPublishView(PublishView):
         # generate exit URL
         exit_url = self.context.absolute_url()
         if clients:
-            exit_url = "{}/{}?uids={}".format(
-                api.get_url(clients[0]), endpoint, ",".join(report_uids))
+            exit_url = api.get_url(clients[0])
 
+        exit_url = "{}/{}?uids={}".format(exit_url, endpoint,
+                                          ",".join(report_uids))
         return exit_url
 
     def ajax_get_reports(self, *args):

--- a/src/senaite/impress/publishview.py
+++ b/src/senaite/impress/publishview.py
@@ -137,8 +137,7 @@ class PublishView(BrowserView):
         grouped_collection = self.group_items_by(group_key, collection)
         is_multi_template = self.is_multi_template(report_template)
 
-        htmls = []
-
+        html_collections = []
         for key, collection in grouped_collection.items():
             # render multi report
             if is_multi_template:
@@ -147,7 +146,7 @@ class PublishView(BrowserView):
                                                 paperformat=paperformat,
                                                 orientation=orientation,
                                                 report_options=report_options)
-                htmls.append(html)
+                html_collections.append((html, collection))
             else:
                 # render single report
                 for model in collection:
@@ -156,7 +155,7 @@ class PublishView(BrowserView):
                                               paperformat=paperformat,
                                               orientation=orientation,
                                               report_options=report_options)
-                    htmls.append(html)
+                    html_collections.append((html, collection))
 
         # generate a PDF for each HTML report
         publisher = self.publisher
@@ -166,7 +165,7 @@ class PublishView(BrowserView):
 
         # wrap the reports for further processing
         reports = []
-        for html, collection in zip(htmls, grouped_collection.values()):
+        for html, collection in html_collections:
             report = getMultiAdapter((html,
                                       collection,
                                       template,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a bug introduced with https://github.com/senaite/senaite.impress/pull/119 that causes the system to only render (and publish) the report for the first selected sample when a "SingleReport"-like template is used.

## Current behavior before PR

System only renders/publishes/emails the first sample when a "SingleReport"-like template is used

## Desired behavior after PR is merged

System renders/publishes/emails all samples when a "SingleReport"-like template is used

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
