### PR TITLE
Fix mixed sorted PoC groups depending on the sample analyses

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.3.0 (unreleased)
 ------------------
 
-- no changes yet
+- #124 Fix mixed sorted PoC groups depending on the sample analyses
 
 
 2.2.0 (2022-06-10)

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -185,7 +185,12 @@ class ReportView(Base):
         """Groups the given analyses by their point of capture
         """
         analyses = self.get_analyses(model_or_collection)
-        return self.group_items_by("PointOfCapture", analyses)
+        groups = self.group_items_by("PointOfCapture", analyses)
+        # Ensure always alphabetic sorting of PoC
+        by_poc = OrderedDict()
+        for key in sorted(groups):
+            by_poc[key] = groups[key]
+        return by_poc
 
     def get_analyses_by_category(self, model_or_collection):
         """Groups the Analyses by their Category


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a sorting issue that might occur when using Field and Lab Analyses together in Samples.
Depending on which analysis is found first when creating the PoC groups, the `lab` PoC might be listed before the `field` PoC

## Current behavior before PR

Field/Lab PoC might be mixed depending on the set of analyses in a sample

## Desired behavior after PR is merged

Field/Lab Poc are always sorted alphabetically => `['field', 'lab']`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
