### PR TITLE
Do not display multi-component analysis in report but analytes

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.3.0 (unreleased)
 ------------------
 
+- #125 Do not display multi-component analysis in report but analytes
 - #124 Fix mixed sorted PoC groups depending on the sample analyses
 
 

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -147,6 +147,8 @@ class ReportView(Base):
         # Boil out analyses meant to be used for internal use only
         analyses = filter(lambda an: not IInternalUse.providedBy(an.instance),
                           analyses)
+        # Do not display multi-component analyses, but their analytes
+        analyses = filter(lambda an: not an.isMultiComponent(), analyses)
         return self.sort_items(analyses)
 
     def get_analyses_by(self, model_or_collection,


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes impress compatible with https://github.com/senaite/senaite.core/pull/2120 , so multi-component analysis is not displayed in results report, but the list of analytes/components only

## Current behavior before PR

Both multi-component and analytes are displayed in results report

## Desired behavior after PR is merged

Only analytes are displayed in results report

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
