### PR TITLE
Fix AttributeError 'Verificators' on model.verifiers call

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.4.0 (unreleased)
 ------------------
 
+- #128 Fix AttributeError 'Verificators' on model.verifiers call
 - #127 Support textarea change events for report options
 
 

--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -240,10 +240,10 @@ class SuperModel(BaseModel):
         userids = [analysis.getVerificators() for analysis in self.Analyses]
         # flatten the list
         userids = list(itertools.chain.from_iterable(userids))
-        # remove empties
-        userids = filter(None, userids)
         # get the users
         for userid in set(userids):
+            if not userid:
+                continue
             user = api.get_user(userid)
             if user is None:
                 logger.warn("Could not find user '{}'".format(userid))

--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -236,9 +236,13 @@ class SuperModel(BaseModel):
         """Returns a list of user objects
         """
         out = []
-        userids = reduce(lambda v1, v2: v1+v2,
-                         map(lambda v: v.Verificators.split(","),
-                             self.Analyses))
+        # extract the ids of the verifiers from all analyses
+        userids = [analysis.getVerificators() for analysis in self.Analyses]
+        # flatten the list
+        userids = list(itertools.chain.from_iterable(userids))
+        # remove empties
+        userids = filter(None, userids)
+        # get the users
         for userid in set(userids):
             user = api.get_user(userid)
             if user is None:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an `AttributeError` when calling the attribute `verifiers` from an AnalysisRequest's model within a results report template:

```html
<tal:something define="collection view/collection;
                       verifiers python: map(lambda m: m.verifiers, collection);">
   ...
</tal:something>
```

## Current behavior before PR

AttributeError: 'Verificators'

## Desired behavior after PR is merged

No AttributeError. Verifier users are returned

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
