### PR TITLE
Fix template error when the report contains invalidated samples

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.4.0 (unreleased)
 ------------------
 
+- #129 Fix template error when the report contains invalidated samples
 - #128 Fix AttributeError 'Verificators' on model.verifiers call
 - #127 Support textarea change events for report options
 

--- a/src/senaite/impress/templates/reports/Default.pt
+++ b/src/senaite/impress/templates/reports/Default.pt
@@ -260,7 +260,7 @@
       <div class="w-100 mb-2">
         <div class="alert alert-danger" tal:condition="model/is_invalid">
           <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
-          <tal:invalidreport tal:define="child model/Retest"
+          <tal:invalidreport tal:define="child python:model.getRetest()"
                              tal:condition="child">
             <span i18n:translate="">This Analysis request has been replaced by</span>
             <a tal:attributes="href child/absolute_url"

--- a/src/senaite/impress/templates/reports/MultiDefault.pt
+++ b/src/senaite/impress/templates/reports/MultiDefault.pt
@@ -265,7 +265,7 @@
           <div class="alert alert-danger" tal:condition="model/is_invalid">
             <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
             <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
-            <tal:invalidreport tal:define="child model/Retest"
+            <tal:invalidreport tal:define="child python:model.getRetest()"
                                tal:condition="child">
               <span i18n:translate="">This Analysis request has been replaced by</span>
               <a tal:attributes="href child/absolute_url"

--- a/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
+++ b/src/senaite/impress/templates/reports/MultiDefaultByColumn.pt
@@ -313,7 +313,7 @@
           <div class="alert alert-danger" tal:condition="model/is_invalid">
             <h2 class="alert-heading"><span tal:replace="model/getId"/></h2>
             <div i18n:translate="">This Analysis Request has been invalidated due to erroneously published results</div>
-            <tal:invalidreport tal:define="child model/Retest"
+            <tal:invalidreport tal:define="child python:model.getRetest()"
                                tal:condition="child">
               <span i18n:translate="">This Analysis request has been replaced by</span>
               <a tal:attributes="href child/absolute_url"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With the PR https://github.com/senaite/senaite.core/pull/2209 the computed field `Retest` was removed from the sample type.

## Current behavior before PR

Template error occurs if the report contains invalidated samples

## Desired behavior after PR is merged

Report works for invalidated samples

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
