### PR TITLE
Change default browserlayer

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.4.0 (unreleased)
 ------------------
 
+- #136 Change default browserlayer
 - #134 Convert impress header table to senaite.app.listing
 - #133 Refactor publish view controls and content table to viewlets
 - #132 Add custom action provider for direct PDF sharing via email

--- a/src/senaite/impress/actions/configure.zcml
+++ b/src/senaite/impress/actions/configure.zcml
@@ -9,7 +9,7 @@
       for="*"
       class=".providers.DownloadPDF"
       permission="zope2.View"
-      layer="senaite.impress.interfaces.ILayer"
+      layer="senaite.impress.interfaces.ISenaiteImpressLayer"
       />
 
   <!-- Send report PDF Action Provider -->
@@ -18,7 +18,7 @@
       for="*"
       class=".providers.SendPDF"
       permission="zope2.View"
-      layer="senaite.impress.interfaces.ILayer"
+      layer="senaite.impress.interfaces.ISenaiteImpressLayer"
       />
 
 </configure>

--- a/src/senaite/impress/browser/publish/configure.zcml
+++ b/src/senaite/impress/browser/publish/configure.zcml
@@ -8,7 +8,7 @@
       name="publish_content_listing"
       class=".content.ContentListingView"
       permission="zope2.View"
-      layer="senaite.impress.interfaces.ILayer"
+      layer="senaite.impress.interfaces.ISenaiteImpressLayer"
       />
 
 </configure>

--- a/src/senaite/impress/browser/viewlets/configure.zcml
+++ b/src/senaite/impress/browser/viewlets/configure.zcml
@@ -16,7 +16,7 @@
       manager=".interfaces.IPublishCustomHtmlHeadViewlets"
       class="senaite.app.listing.browser.viewlets.resources.ResourcesViewlet"
       permission="zope2.View"
-      layer="senaite.impress.interfaces.ILayer"
+      layer="senaite.impress.interfaces.ISenaiteImpressLayer"
       />
 
   <!-- Favicon viewlet -->

--- a/src/senaite/impress/configure.zcml
+++ b/src/senaite/impress/configure.zcml
@@ -29,7 +29,7 @@
       name="printview"
       class="senaite.impress.publishview.PublishView"
       permission="senaite.core.permissions.ManageAnalysisRequests"
-      layer="senaite.impress.interfaces.ILayer"
+      layer="senaite.impress.interfaces.ISenaiteImpressLayer"
       />
 
   <!-- Publish View -->
@@ -38,7 +38,7 @@
       name="publish"
       class="senaite.impress.publishview.PublishView"
       permission="senaite.core.permissions.ManageAnalysisRequests"
-      layer="senaite.impress.interfaces.ILayer"
+      layer="senaite.impress.interfaces.ISenaiteImpressLayer"
       />
 
   <!-- Client Publish View -->
@@ -47,7 +47,7 @@
       name="publish"
       class="senaite.impress.publishview.PublishView"
       permission="senaite.core.permissions.ManageAnalysisRequests"
-      layer="senaite.impress.interfaces.ILayer"
+      layer="senaite.impress.interfaces.ISenaiteImpressLayer"
       />
 
   <!-- Sample Publish View -->
@@ -56,7 +56,7 @@
       name="publish"
       class="senaite.impress.publishview.PublishView"
       permission="senaite.core.permissions.ManageAnalysisRequests"
-      layer="senaite.impress.interfaces.ILayer"
+      layer="senaite.impress.interfaces.ISenaiteImpressLayer"
       />
 
   <!-- Batch Publish View -->
@@ -65,7 +65,7 @@
       name="publish"
       class="senaite.impress.publishview.PublishView"
       permission="senaite.core.permissions.ManageAnalysisRequests"
-      layer="senaite.impress.interfaces.ILayer"
+      layer="senaite.impress.interfaces.ISenaiteImpressLayer"
       />
 
   <!-- Ajax Publish Controller View -->
@@ -74,7 +74,7 @@
       name="ajax_publish"
       class="senaite.impress.ajax.AjaxPublishView"
       permission="zope.Public"
-      layer="senaite.impress.interfaces.ILayer"
+      layer="senaite.impress.interfaces.ISenaiteImpressLayer"
       />
 
   <!-- Publisher Controlpanel -->
@@ -83,7 +83,7 @@
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       class=".controlpanel.ImpressControlPanelView"
       permission="senaite.core.permissions.ManageBika"
-      layer="senaite.impress.interfaces.ILayer"
+      layer="senaite.impress.interfaces.ISenaiteImpressLayer"
       />
 
   <!-- Generic Model -->

--- a/src/senaite/impress/profiles/default/browserlayer.xml
+++ b/src/senaite/impress/profiles/default/browserlayer.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
 <layers>
+  <!-- Register default browserlayer -->
   <layer name="senaite.impress"
+         interface="senaite.impress.interfaces.ISenaiteImpressLayer" />
+  <!-- BBB: Remove this in version 2.5 -->
+  <layer remove="True"
          interface="senaite.impress.interfaces.ILayer" />
 </layers>

--- a/src/senaite/impress/profiles/default/metadata.xml
+++ b/src/senaite/impress/profiles/default/metadata.xml
@@ -1,3 +1,3 @@
 <metadata>
-  <version>2402</version>
+  <version>2403</version>
 </metadata>

--- a/src/senaite/impress/profiles/uninstall/browserlayer.xml
+++ b/src/senaite/impress/profiles/uninstall/browserlayer.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <layers>
-  <!-- Remove Browser Layer -->
-  <layer name="senaite.impress"
-         interface="senaite.impress.interfaces.ILayer"
+  <!-- Remove default browser layer -->
+  <layer interface="senaite.impress.interfaces.ISenaiteImpressLayer"
          remove="True" />
 </layers>

--- a/src/senaite/impress/profiles/uninstall/metadata.xml
+++ b/src/senaite/impress/profiles/uninstall/metadata.xml
@@ -1,3 +1,0 @@
-<metadata>
-  <version>2400</version>
-</metadata>

--- a/src/senaite/impress/upgrades/v02_04_000.py
+++ b/src/senaite/impress/upgrades/v02_04_000.py
@@ -24,3 +24,13 @@ def import_registry(tool):
     logger.info("Import SENAITE IMPRESS registry ...")
     tool.runImportStepFromProfile(PROFILE_ID, "plone.app.registry")
     logger.info("Import SENAITE IMPRESS registry [DONE]")
+
+
+def import_browserlayer(tool):
+    """Import browser layer
+
+    :param tool: portal_setup tool
+    """
+    logger.info("Import SENAITE IMPRESS browser layer ...")
+    tool.runImportStepFromProfile(PROFILE_ID, "browserlayer")
+    logger.info("Import SENAITE IMPRESS browser layer [DONE]")

--- a/src/senaite/impress/upgrades/v02_04_000.zcml
+++ b/src/senaite/impress/upgrades/v02_04_000.zcml
@@ -20,4 +20,12 @@
       handler="senaite.impress.upgrades.v02_04_000.import_registry"
       profile="senaite.impress:default"/>
 
+  <genericsetup:upgradeStep
+      title="SENAITE IMPRESS 2.4.0: Change default browser layer"
+      description="Change default browser layer from ILayer -> ISenaiteImpressLayer"
+      source="2402"
+      destination="2403"
+      handler="senaite.impress.upgrades.v02_04_000.import_browserlayer"
+      profile="senaite.impress:default"/>
+
 </configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the default browser layer from `ILayer` -> `ISenaiteImpressLayer` for all registered components.

## Current behavior before PR

The change of https://github.com/senaite/senaite.impress/commit/e109cb01e0068d058dd0a1c3084bd68b193a3ab5 broke the report rendering of reports, because the resource viewlets for the required ReactJS were not rendered for a vanilla SENAITE site.

## Desired behavior after PR is merged

Reports of a vanilla SENAITE site render correctly with the new listing header table that was introduced in https://github.com/senaite/senaite.impress/pull/134 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
