### PR TITLE
Display reportable interim fields as result variables in results report

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
+- #141 Display reportable interim fields as result variables in results report
 - #140 Refactor report sections into separate components
 
 

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -29,6 +29,7 @@ import DateTime
 from bika.lims import POINTS_OF_CAPTURE
 from bika.lims import api
 from bika.lims.interfaces import IInternalUse
+from bika.lims.utils.analysis import format_interim
 from bika.lims.workflow import getTransitionDate
 from Products.CMFPlone.i18nl10n import ulocalized_time
 from Products.CMFPlone.utils import safe_unicode
@@ -357,6 +358,31 @@ class ReportView(Base):
         """Check if the given object is a SuperModel
         """
         return ISuperModel.providedBy(obj)
+
+    def get_result_variables(self, analysis, report_only=True):
+        """Returns the result variables (aka interim fields) from the given
+        analysis, with additional attributes formatted_result and
+        formatted_unit. If report_only is True, only result variables that are
+        flagged with attribute "report" are returned.
+
+        :param analysis: Analysis' object/supermodel/brain or UID
+        :param report_only: Only result variables flagged with 'report:True'
+        :returns: List of result variable items
+        """
+        items = []
+        obj = api.get_object(analysis)
+        interim_fields = obj.getInterimFields() or []
+        for interim_field in interim_fields:
+
+            # skip interim not fields flagged with report
+            if report_only and not interim_field.get("report", False):
+                continue
+
+            # apply formatting
+            item = format_interim(interim_field)
+            items.append(item)
+
+        return items
 
 
 class SingleReportView(ReportView):

--- a/src/senaite/impress/analysisrequest/templates/css.pt
+++ b/src/senaite/impress/analysisrequest/templates/css.pt
@@ -28,6 +28,7 @@
    .report .section-header img.logo { height: 30px; margin: 20px 0; }
    .report .barcode-hri { margin-top: -0.25em; font-size: 8pt; }
    .report .section-results .methodtitle { font-size: 85%; }
+   .report .section-results .results_interims { font-size: 85%; }
    .report .section-footer table td { border: none; }
    .report .section-footer {
      position: fixed;

--- a/src/senaite/impress/analysisrequest/templates/results.pt
+++ b/src/senaite/impress/analysisrequest/templates/results.pt
@@ -1,6 +1,7 @@
 <tal:t define="collection python:view.collection;
                accredited_symbol string:★;
-               outofrange_symbol string:⚠;"
+               outofrange_symbol string:⚠;
+               global results_interims python:[]"
        i18n:domain="senaite.impress">
 
   <tal:model repeat="model collection">
@@ -66,6 +67,14 @@
                       <span tal:condition="analysis/ScientificName">
                         <span class="font-italic" tal:content="analysis/title"></span>
                       </span>
+
+                      <tal:interim_fields
+                          define="interims python:view.get_result_variables(analysis)"
+                          condition="interims">
+                        <sup tal:define="dummy python:results_interims.append(interims)"
+                             tal:content="python: len(results_interims)"/>
+                      </tal:interim_fields>
+
                       <!-- Method -->
                       <div class="text-secondary methodtitle"
                            i18n:translate=""
@@ -104,6 +113,25 @@
                          tal:content="category_comments">
                       Category Comments
                     </div>
+                  </td>
+                </tr>
+                <tr tal:condition="results_interims">
+                  <td colspan="3">
+                    <ul class="list-unstyled results_interims">
+                      <li tal:repeat="interims results_interims" class="mt-2">
+                        <sup tal:content="repeat/interims/number"/>
+                        <tal:interims repeat="interim interims">
+                          <tal:interim>
+                            <br tal:condition="repeat/interim/index"/>
+                            <span tal:condition="repeat/interim/index" class="pl-2"/>
+                            <span tal:content="interim/title"/>
+                            (<span tal:content="interim/keyword"/>):
+                            <span tal:content="interim/formatted_value"/>
+                            <span tal:content="interim/formatted_unit"/>
+                          </tal:interim>
+                        </tal:interims>
+                      </li>
+                    </ul>
                   </td>
                 </tr>
               </tfoot>

--- a/src/senaite/impress/analysisrequest/templates/results.pt
+++ b/src/senaite/impress/analysisrequest/templates/results.pt
@@ -124,8 +124,7 @@
                           <tal:interim>
                             <br tal:condition="repeat/interim/index"/>
                             <span tal:condition="repeat/interim/index" class="pl-2"/>
-                            <span tal:content="interim/title"/>
-                            (<span tal:content="interim/keyword"/>):
+                            <span tal:content="interim/title"/>:
                             <span tal:content="interim/formatted_value"/>
                             <span tal:content="interim/formatted_unit"/>
                           </tal:interim>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!IMPORTANT]  
> Please review and merge https://github.com/senaite/senaite.core/pull/2365 first

This Pull Request adds a footer section in results table where the interim fields flagged with `report=True` are displayed.

## Current behavior before PR

Interim fields flagged with `report=True` are not displayed and there is no function to get them easily

## Desired behavior after PR is merged

Interim fields flagged with `Report=True` are displayed and there is an easy function to get them.

Result variables in Calculation/Service:

![Captura de 2023-08-25 12-21-18](https://github.com/senaite/senaite.impress/assets/832627/248a1fe7-c0a9-48ad-abff-fff8f94830f2)

Results entry:

![Captura de 2023-08-25 12-10-10](https://github.com/senaite/senaite.impress/assets/832627/37fc86c2-5c53-47df-84d3-5849a9c1d07e)

Results report:

![Captura de 2023-08-25 12-23-17](https://github.com/senaite/senaite.impress/assets/832627/92c9ab30-7100-4966-b315-e9e595bffef8)




--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
