### PR TITLE
Display custom comment for out of range results

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
+- #142 Display custom comment for out of range results
 - #141 Display reportable interim fields as result variables in results report
 - #140 Refactor report sections into separate components
 

--- a/src/senaite/impress/analysisrequest/templates/results.pt
+++ b/src/senaite/impress/analysisrequest/templates/results.pt
@@ -47,7 +47,7 @@
                     <span i18n:translate="">Range</span>
                   </th>
                   <th class="outofrange">
-                    <span i18n:translate=""></span>
+                    <span/>
                   </th>
                 </tr>
               </thead>
@@ -93,14 +93,25 @@
                       <span tal:content="python:'(RT)' if model.is_retest(analysis) else ''"></span>
                       <span tal:content="python:model.get_formatted_specs(analysis)">50 - 60</span>
                     </td>
-                    <td class="text-center align-middle">
-                      <span tal:condition="python:model.is_out_of_range(analysis)"
-                            class="font-weight-light">
-                        <span class="outofrange text-danger"
+
+                    <!-- Out of range column -->
+                    <td class="text-center align-middle"
+                        tal:define="out_of_range  python: model.is_out_of_range(analysis);
+                                    results_range python: analysis.getResultsRange();
+                                    comment       python: results_range.get('rangecomment');">
+                      <tal:out_of_range condition="out_of_range">
+
+                        <!-- Out of range symbol -->
+                        <span class="font-weight-light outofrange text-danger"
                               style="font-family:Lucida Console, Courier, monospace;"
                               tal:content="outofrange_symbol">
                         </span>
-                      </span>
+
+                        <!-- Out-of-range comment -->
+                        <span tal:condition="comment" tal:content="comment"/>
+
+                      </tal:out_of_range>
+
                     </td>
                   </tr>
                 </tal:analyses>

--- a/src/senaite/impress/analysisrequest/templates/results.pt
+++ b/src/senaite/impress/analysisrequest/templates/results.pt
@@ -108,7 +108,7 @@
                         </span>
 
                         <!-- Out-of-range comment -->
-                        <span class="font-weight-light text-danger small"
+                        <span class="text-danger small"
                               tal:condition="comment" tal:content="comment"/>
 
                       </tal:out_of_range>

--- a/src/senaite/impress/analysisrequest/templates/results.pt
+++ b/src/senaite/impress/analysisrequest/templates/results.pt
@@ -108,7 +108,8 @@
                         </span>
 
                         <!-- Out-of-range comment -->
-                        <span tal:condition="comment" tal:content="comment"/>
+                        <span class="font-weight-light text-danger small"
+                              tal:condition="comment" tal:content="comment"/>
 
                       </tal:out_of_range>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!IMPORTANT]  
> **Merge https://github.com/senaite/senaite.core/pull/2369 first**

This Pull Request displays the custom comment next to the out of range icon when properly set in the specifications

## Current behavior before PR

No custom comment is displayed for results that are out of range

## Desired behavior after PR is merged

Custom comment is displayed for results that are out of range
![Captura de 2023-09-01 14-12-22](https://github.com/senaite/senaite.impress/assets/832627/86729bd7-5050-4a14-b7a1-e44e0c4face8)



--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
