### PR TITLE
Fix user defined range operators are omitted in results report

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
+- #143 Fix user defined range operators are omitted in results report
 - #142 Display custom comment for out of range results
 - #141 Display reportable interim fields as result variables in results report
 - #140 Refactor report sections into separate components

--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -28,6 +28,8 @@ from bika.lims import api
 from senaite.app.supermodel import SuperModel as BaseModel
 from senaite.impress import logger
 from senaite.impress.decorators import returns_super_model
+from bika.lims.config import MAX_OPERATORS
+from bika.lims.config import MIN_OPERATORS
 
 
 class SuperModel(BaseModel):
@@ -146,13 +148,22 @@ class SuperModel(BaseModel):
 
     def get_formatted_specs(self, analysis):
         specs = analysis.getResultsRange()
+
+        # get the min operator
+        min_operator = specs.get("min_operator")
+        min_operator = MIN_OPERATORS.getValue(min_operator, default=">")
+
+        # get the max operator
+        max_operator = specs.get("max_operator")
+        max_operator = MIN_OPERATORS.getValue(max_operator, default=">")
+
         fs = ''
         if specs.get('min', None) and specs.get('max', None):
             fs = '%s - %s' % (specs['min'], specs['max'])
         elif specs.get('min', None):
-            fs = '> %s' % specs['min']
+            fs = '%s %s' % (min_operator, specs['min'])
         elif specs.get('max', None):
-            fs = '< %s' % specs['max']
+            fs = '%s %s' % (max_operator, specs['max'])
         return formatDecimalMark(fs, self.decimal_mark)
 
     def get_resultsinterpretation(self):

--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -20,16 +20,16 @@
 
 import itertools
 
+from bika.lims import api
+from bika.lims.config import MAX_OPERATORS
+from bika.lims.config import MIN_OPERATORS
 from bika.lims.utils import format_supsub
 from bika.lims.utils import formatDecimalMark
 from bika.lims.utils import to_utf8
 from bika.lims.utils.analysis import format_uncertainty
-from bika.lims import api
 from senaite.app.supermodel import SuperModel as BaseModel
 from senaite.impress import logger
 from senaite.impress.decorators import returns_super_model
-from bika.lims.config import MAX_OPERATORS
-from bika.lims.config import MIN_OPERATORS
 
 
 class SuperModel(BaseModel):
@@ -155,7 +155,7 @@ class SuperModel(BaseModel):
 
         # get the max operator
         max_operator = specs.get("max_operator")
-        max_operator = MIN_OPERATORS.getValue(max_operator, default="<")
+        max_operator = MAX_OPERATORS.getValue(max_operator, default="<")
 
         fs = ''
         if specs.get('min', None) and specs.get('max', None):

--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -155,7 +155,7 @@ class SuperModel(BaseModel):
 
         # get the max operator
         max_operator = specs.get("max_operator")
-        max_operator = MIN_OPERATORS.getValue(max_operator, default=">")
+        max_operator = MIN_OPERATORS.getValue(max_operator, default="<")
 
         fs = ''
         if specs.get('min', None) and specs.get('max', None):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that the operators for result ranges from Specification are considered in results reports.

## Current behavior before PR

System always use '>' or '<' operators, regardless of the operator set in Specifications

## Desired behavior after PR is merged

System uses the operator set in Specifications

![Captura de 2023-10-03 18-27-56](https://github.com/senaite/senaite.impress/assets/832627/8c5e09b7-19d8-4bf5-8bfa-b73c4c1d0c29)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
