### PR TITLE
Fix Error: DisplayList keys must be strings, got <type 'NoneType'>

### DIFF
--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -150,11 +150,11 @@ class SuperModel(BaseModel):
         specs = analysis.getResultsRange()
 
         # get the min operator
-        min_operator = specs.get("min_operator")
+        min_operator = specs.get("min_operator") or ""
         min_operator = MIN_OPERATORS.getValue(min_operator, default=">")
 
         # get the max operator
-        max_operator = specs.get("max_operator")
+        max_operator = specs.get("max_operator") or ""
         max_operator = MAX_OPERATORS.getValue(max_operator, default="<")
 
         fs = ''


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an `Error: DisplayList keys must be strings, got <type 'NoneType'>` introduced with https://github.com/senaite/senaite.impress/pull/143 when analysis does not have a `min_operator` or `max_operator` set in the specs

## Current behavior before PR

`Error: DisplayList keys must be strings, got <type 'NoneType'>`

## Desired behavior after PR is merged

No error

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
