### PR TITLE
Dynamic PDF group key lookup

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
+- #145 Dynamic PDF group key lookup
 - #143 Fix user defined range operators are omitted in results report
 - #142 Display custom comment for out of range results
 - #141 Display reportable interim fields as result variables in results report

--- a/src/senaite/impress/adapters.py
+++ b/src/senaite/impress/adapters.py
@@ -21,7 +21,23 @@
 from bika.lims import api
 from senaite.impress import senaiteMessageFactory as _
 from senaite.impress.interfaces import ICustomActionProvider
+from senaite.impress.interfaces import IGroupKeyProvider
 from zope.interface import implementer
+
+
+@implementer(IGroupKeyProvider)
+class GroupKeyProvider(object):
+    """Provide a grouping key for PDF separation
+    """
+    def __init__(self, context):
+        self.context = context
+
+    def __call__(self):
+        try:
+            # split samples from different clients
+            return self.context.getClientUID()
+        except AttributeError:
+            return "_nogroup_"
 
 
 @implementer(ICustomActionProvider)

--- a/src/senaite/impress/ajax.py
+++ b/src/senaite/impress/ajax.py
@@ -202,7 +202,7 @@ class AjaxPublishView(PublishView):
 
         # generate the reports
         reports = self.generate_reports_for(uids,
-                                            group_by="getClientUID",
+                                            group_by=self.make_group_key,
                                             template=template,
                                             paperformat=paperformat,
                                             orientation=orientation,

--- a/src/senaite/impress/configure.zcml
+++ b/src/senaite/impress/configure.zcml
@@ -152,6 +152,12 @@
       factory=".adapters.SendPDFActionProvider"
       />
 
+  <!-- PDF Grouping Key Provider -->
+  <adapter
+      for="*"
+      factory=".adapters.GroupKeyProvider"
+      />
+
   <!-- Report resource directory -->
   <plone:static
       directory="templates/reports"

--- a/src/senaite/impress/interfaces.py
+++ b/src/senaite/impress/interfaces.py
@@ -103,3 +103,11 @@ class ICustomActionProvider(Interface):
     def get_action_data():
         """Returns the known attributes to the ReactJS component
         """
+
+
+class IGroupKeyProvider(Interface):
+    """Adapter to provide a grouping key to split report PDFs
+    """
+    def __call__():
+        """Return a grouping key string
+        """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to provide a custom group key to split PDFs by a custom criteria, e.g. the Client UID *and* the Patient MRN if `senaite.patient` is installed.

### Example code

```python
from bika.lims.interfaces import IAnalysisRequest
from senaite.impress.interfaces import IGroupKeyProvider
from zope.component import adapter
from zope.interface import implementer


@implementer(IGroupKeyProvider)
@adapter(IAnalysisRequest)
class GroupKeyProvider(object):
    """Provide a grouping key for PDF separation
    """
    def __init__(self, context):
        self.context = context

    def __call__(self):
        client_uid = self.context.getClientUID()
        mrn = self.context.getMedicalRecordNumberValue()
        if mrn:
            return "%s_%s" % (client_uid, mrn)
        return client_uid

```

## Current behavior before PR

PDFs are grouped hard coded by the key `getClientUID`.

## Desired behavior after PR is merged

Group key retrieved  by an Adapter lookup on the object.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
