### PR TITLE
Compatibility with senaite.app.supermodel#23

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
-- no changes yet
+- #149 Compatibility with senaite.app.supermodel#23
 
 
 2.5.0 (2024-01-03)

--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -226,6 +226,17 @@ class SuperModel(BaseModel):
 
     @property
     @returns_super_model
+    def Analyses(self):
+        """Returns the analyses of this sample, those from partitions included
+        """
+        # SuperModel uses getRawAnalyses by default, that only returns the
+        # analyses that belong to the current sample. On the other hand,
+        # getAnalyses() returns the analyses from the current sample, plus
+        # those from partitions
+        return self.getAnalyses()
+
+    @property
+    @returns_super_model
     def departments(self):
         return self.getDepartments()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!WARNING]  
> Merge https://github.com/senaite/senaite.core/pull/2602 first!

Analyses from partitions are no longer displayed in results reports because with https://github.com/senaite/senaite.app.supermodel/pull/23 , `sample.Analyses` does no longer relies on `getAnalyses` but on `getRawAnalyses`. The latter returns only the uids of the analyses directly contained (see https://github.com/senaite/senaite.core/pull/2593), while the former contains those contained plus those that belong to partitions.

Since impress has its own SuperModel adapter for `AnalysisRequest`, we assume that on publish scenario, `model.Analyses` should return all analyses, those from partitions included. 

## Current behavior before PR

Analyses from partitions are no longer displayed in results reports

## Desired behavior after PR is merged

Analyses from partitions are displayed in results reports

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
