### PR TITLE
Fix URLFetchingError when generating report without HOST in request header

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
-- no changes yet
+- #150 Fix URLFetchingError when generating report w/o HOST in request header
 
 
 2.5.0 (2024-01-03)

--- a/src/senaite/impress/publisher.py
+++ b/src/senaite/impress/publisher.py
@@ -165,7 +165,7 @@ class Publisher(object):
         portal = api.get_portal()
         context = portal.restrictedTraverse(path, None)
 
-        if context is None or host not in url:
+        if context is None or (host and host not in url):
             logger.info("External URL, delegate to default URL fetcher...")
             return default_url_fetcher(url)
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an `URLFetchingError` when trying to fetch CSS resources on report creation without the `HOST` header in the request. This is happening when the report is generated by directly using a python script (the request is for `http://nohost`).

## Current behavior before PR

System can fetch the CSS resources normally without error and the report is generated

## Desired behavior after PR is merged

System can fetch the CSS resources normally without error and the report is generated


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
