### PR TITLE
Support for analysis conditions

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #155 Support for analysis conditions
 - #153 Update ReactJS 18 -> 19
 - #152 jQuery3 compatibility
 

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -17,7 +17,7 @@
 #
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
-
+import copy
 from collections import Iterable
 from collections import OrderedDict
 from collections import Sequence
@@ -29,12 +29,14 @@ import DateTime
 from bika.lims import POINTS_OF_CAPTURE
 from bika.lims import api
 from bika.lims.interfaces import IInternalUse
+from bika.lims.utils import get_link
 from bika.lims.utils.analysis import format_interim
 from bika.lims.workflow import getTransitionDate
 from Products.CMFPlone.i18nl10n import ulocalized_time
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile as PT
 from senaite.app.supermodel.interfaces import ISuperModel
+from senaite.impress import senaiteMessageFactory as _
 from senaite.impress import logger
 from senaite.impress.decorators import returns_super_model
 from senaite.impress.reportview import ReportView as Base
@@ -381,6 +383,74 @@ class ReportView(Base):
             # apply formatting
             item = format_interim(interim_field)
             items.append(item)
+
+        return items
+
+    def is_true(self, val):
+        """Returns whether val evaluates to True
+        """
+        if not val:
+            return False
+        val = str(val).strip().lower()
+        return val in ["y", "yes", "1", "true", "on"]
+
+    def get_attachment_link(self, attachment):
+        """Returns a well-formed link for the attachment passed in
+        """
+        filename = attachment.getFilename()
+        att_url = api.get_url(attachment)
+        url = "{}/at_download/AttachmentFile".format(att_url)
+        return get_link(url, filename, tabindex="-1")
+
+    def format_condition(self, condition):
+        """Returns a string representation of the analysis condition value
+        """
+        title = condition.get("title")
+        value = condition.get("value", "")
+        if not any([title, value]):
+            return None
+
+        texts = {True: _("Yes"), False: _("No")}
+        condition_type = condition.get("type")
+        if condition_type == "checkbox":
+            value = texts.get(self.is_true(value))
+
+        elif condition_type == "file":
+            attachment = api.get_object_by_uid(value, None)
+            if not attachment:
+                return None
+            value = self.get_attachment_link(attachment)
+
+        return api.to_utf8(str(value))
+
+    def get_analysis_conditions(self, analysis, report_only=True):
+        """Returns the (pre)conditions from the given analysis, that have a
+        valid value set, with the additional attribute 'formatted_value'. If
+        'report_only' is True, only conditions that are flagged with attribute
+        "report" are returned.
+
+        :param analysis: Analysis' object/supermodel/brain or UID
+        :param report_only: Only conditions flagged with 'report:True'
+        :returns: List of anaysis conditions items
+        """
+        # analysis (pre)conditions
+        items = []
+        analysis = api.get_object(analysis)
+        conditions = analysis.getConditions() or []
+        for condition in conditions:
+
+            # skip conditions flagged with report
+            if not condition.get("report", False):
+                continue
+
+            # skip those without a valid format
+            formatted = self.format_condition(condition)
+            if not formatted:
+                continue
+
+            # apply formatting
+            condition["formatted_value"] = formatted
+            items.append(condition)
 
         return items
 

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -17,7 +17,7 @@
 #
 # Copyright 2018-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
-import copy
+
 from collections import Iterable
 from collections import OrderedDict
 from collections import Sequence
@@ -439,8 +439,9 @@ class ReportView(Base):
         conditions = analysis.getConditions() or []
         for condition in conditions:
 
-            # skip conditions flagged with report
-            if not condition.get("report", False):
+            # skip non-reportable conditions
+            report = condition.get("report", False)
+            if not self.is_true(report):
                 continue
 
             # skip those without a valid format

--- a/src/senaite/impress/analysisrequest/templates/controls.pt
+++ b/src/senaite/impress/analysisrequest/templates/controls.pt
@@ -1,6 +1,7 @@
 <tal:t define="report_options python:options.get('report_options', {});
                attachments_per_row python:int(report_options.get('attachments_per_row', 2));
-               show_remarks python:bool(report_options.get('show_remarks', False));"
+               show_remarks python:bool(report_options.get('show_remarks', False));
+               show_conditions python:bool(report_options.get('show_conditions', True));"
        i18n:domain="senaite.impress">
 
   <!-- Custom Report Controls -->
@@ -25,6 +26,20 @@
         </div>
         <small class="form-text text-muted" i18n:translate="">
           Show Sample Remarks
+        </small>
+      </div>
+      <!-- Show analysis conditions -->
+      <div class="mb-3">
+        <div class="input-group">
+          <div class="custom-control custom-checkbox">
+            <input tal:attributes="checked python:show_conditions" name="show_conditions" type="checkbox" class="custom-control-input" id="show-conditions">
+            <label class="custom-control-label" for="show-conditions">
+              Analysis conditions
+            </label>
+          </div>
+        </div>
+        <small class="form-text text-muted" i18n:translate="">
+          Display the analysis conditions with the 'Report' option selected as footnotes below the results table.
         </small>
       </div>
       <!-- Attachments per row -->

--- a/src/senaite/impress/analysisrequest/templates/css.pt
+++ b/src/senaite/impress/analysisrequest/templates/css.pt
@@ -22,6 +22,8 @@
    .report table td.label { padding-right: 0.3rem; font-weight: bold; }
    .report table { border-color: black; }
    .report table td, .report table th { border-top: 1px solid black; border-bottom: 1px solid black; }
+   .report table tr:has(+ tr.conditions) td { border-bottom: none; }
+   .report table tr.conditions td { border-top: none; }
    .report table th { border-bottom: 1px solid black; }
    .report table.range-table td { padding: 0 0.3rem 0 0; border: none; }
    .report .section-header h1 { font-size: 175%; }

--- a/src/senaite/impress/analysisrequest/templates/css.pt
+++ b/src/senaite/impress/analysisrequest/templates/css.pt
@@ -22,8 +22,6 @@
    .report table td.label { padding-right: 0.3rem; font-weight: bold; }
    .report table { border-color: black; }
    .report table td, .report table th { border-top: 1px solid black; border-bottom: 1px solid black; }
-   .report table tr:has(+ tr.conditions) td { border-bottom: none; }
-   .report table tr.conditions td { border-top: none; }
    .report table th { border-bottom: 1px solid black; }
    .report table.range-table td { padding: 0 0.3rem 0 0; border: none; }
    .report .section-header h1 { font-size: 175%; }

--- a/src/senaite/impress/analysisrequest/templates/results.pt
+++ b/src/senaite/impress/analysisrequest/templates/results.pt
@@ -1,7 +1,9 @@
 <tal:t define="collection python:view.collection;
                accredited_symbol string:★;
                outofrange_symbol string:⚠;
-               global results_interims python:[]"
+               global footnotes python:[];
+               report_options python:options.get('report_options', {});
+               show_conditions python:bool(report_options.get('show_conditions', True));"
        i18n:domain="senaite.impress">
 
   <tal:model repeat="model collection">
@@ -68,12 +70,28 @@
                         <span class="font-italic" tal:content="analysis/title"></span>
                       </span>
 
-                      <tal:interim_fields
-                          define="interims python:view.get_result_variables(analysis)"
-                          condition="interims">
-                        <sup tal:define="dummy python:results_interims.append(interims)"
-                             tal:content="python: len(results_interims)"/>
-                      </tal:interim_fields>
+                      <tal:analysis_footnotes define="analysis_footnotes python:[];">
+
+                        <!-- Include conditions in the footnotes for this analysis -->
+                        <tal:analysis_conditions
+                          define="conditions python:view.get_analysis_conditions(analysis)"
+                          condition="show_conditions">
+                          <tal:x define="dummy python:analysis_footnotes.extend(conditions)">
+                        </tal:analysis_conditions>
+
+                        <!-- Include interims in the footnotes for this analysis -->
+                        <tal:interim_fields
+                            define="interims python:view.get_result_variables(analysis);
+                                    dummy python:analysis_footnotes.extend(interims)">
+                        </tal:interim_fields>
+
+                        <!-- Add the analysis footnotes to the global footnotes -->
+                        <tal:x condition="analysis_footnotes">
+                          <sup tal:define="dummy python:footnotes.append(analysis_footnotes)"
+                               tal:content="python: len(footnotes)"/>
+                        </tal:x>
+
+                      </tal:analysis_footnotes>
 
                       <!-- Method -->
                       <div class="text-secondary methodtitle"
@@ -127,20 +145,19 @@
                     </div>
                   </td>
                 </tr>
-                <tr tal:condition="results_interims">
+                <tr tal:condition="footnotes">
                   <td colspan="3">
-                    <ul class="list-unstyled results_interims">
-                      <li tal:repeat="interims results_interims" class="mt-2">
-                        <sup tal:content="repeat/interims/number"/>
-                        <tal:interims repeat="interim interims">
-                          <tal:interim>
-                            <br tal:condition="repeat/interim/index"/>
-                            <span tal:condition="repeat/interim/index" class="pl-2"/>
-                            <span tal:content="interim/title"/>:
-                            <span tal:content="interim/formatted_value"/>
-                            <span tal:content="interim/formatted_unit"/>
-                          </tal:interim>
-                        </tal:interims>
+                    <ul class="list-unstyled footnotes">
+                      <li tal:repeat="analysis_footnotes footnotes" class="mt-2">
+                        <sup tal:content="repeat/analysis_footnotes/number"/>
+                        <tal:footnotes repeat="footnote analysis_footnotes">
+                          <tal:footnote>
+                            <span tal:condition="repeat/footnote/index" class="pl-2"/>
+                            <span tal:content="footnote/title"/>:
+                            <span tal:content="footnote/formatted_value"/>
+                            <span tal:content="footnote/formatted_unit|nothing"/>
+                          </tal:footnote>
+                        </tal:footnotes>
                       </li>
                     </ul>
                   </td>

--- a/src/senaite/impress/analysisrequest/templates/results.pt
+++ b/src/senaite/impress/analysisrequest/templates/results.pt
@@ -152,6 +152,7 @@
                         <sup tal:content="repeat/analysis_footnotes/number"/>
                         <tal:footnotes repeat="footnote analysis_footnotes">
                           <tal:footnote>
+                            <br tal:condition="repeat/footnote/index"/>
                             <span tal:condition="repeat/footnote/index" class="pl-2"/>
                             <span tal:content="footnote/title"/>:
                             <span tal:content="footnote/formatted_value"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!WARNING]
> Requirements:
> - https://github.com/senaite/senaite.core/pull/2740

This Pull Request introduces support for analysis conditions with the addition of a new report option, 'Analysis Conditions.' When enabled, analysis conditions marked as 'reportable' are displayed as footnotes at the bottom of the results table, alongside analysis variables (also known as interim values).

![20250604120130](https://github.com/user-attachments/assets/934b6fdc-0ca5-42e3-89de-c18c83d71b70)

![20250604115615](https://github.com/user-attachments/assets/5a6bba2c-d090-4a85-b67d-aba03a3e83cd)


## Current behavior before PR

Is not possible to display analysis conditions in results report

## Desired behavior after PR is merged

It is possible to display analysis conditions in results report

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
