### PR TITLE
Fix [+- ] symbol is displayed when uncertainty does not apply

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #159 Fix [+- ] symbol is displayed when uncertainty does not apply
 - #157 Fix custom scripts not rendered in final PDF
 - #156 Fix condition syntax in alerts template for invalid sample
 - #155 Support for analysis conditions

--- a/src/senaite/impress/analysisrequest/model.py
+++ b/src/senaite/impress/analysisrequest/model.py
@@ -144,7 +144,7 @@ class SuperModel(BaseModel):
             analysis.instance,
             decimalmark=self.decimal_mark,
             sciformat=self.scientific_notation)
-        return "[&plusmn; {}]".format(uncertainty)
+        return "[&plusmn; {}]".format(uncertainty) if uncertainty else ""
 
     def get_formatted_specs(self, analysis):
         specs = analysis.getResultsRange()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request updates the function `get_formatted_uncertainty` that relies on `Supermodel`, so it does return empty when no uncertainty is set.

## Current behavior before PR

`[+- ]` symbol is displayed when uncertainty does not apply

## Desired behavior after PR is merged

`[+- ]` symbol is displayed only when uncertainty applies

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
