### PR TITLE
Fix categories without SortKey are displayed first

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #160 Fix categories without SortKey are displayed first
 - #157 Fix custom scripts not rendered in final PDF
 - #156 Fix condition syntax in alerts template for invalid sample
 - #155 Support for analysis conditions

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -33,9 +33,10 @@ from bika.lims.utils import get_link
 from bika.lims.utils.analysis import format_interim
 from bika.lims.workflow import getTransitionDate
 from Products.CMFPlone.i18nl10n import ulocalized_time
-from Products.CMFPlone.utils import safe_unicode
+from Products.CMFPlone.utils import safe_callable
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile as PT
 from senaite.app.supermodel.interfaces import ISuperModel
+from senaite.core.catalog.utils import sortable_sortkey_title
 from senaite.impress import senaiteMessageFactory as _
 from senaite.impress import logger
 from senaite.impress.decorators import returns_super_model
@@ -276,9 +277,10 @@ class ReportView(Base):
         """Default sort which mixes in the sort key
         """
         def sortable_title(obj):
-            sort_key = obj.get("SortKey") or 0.0
-            title = obj.title.lower()
-            return u"{:010.3f}{}".format(sort_key, safe_unicode(title))
+            title = sortable_sortkey_title(obj)
+            if safe_callable(title):
+                title = title()
+            return title
 
         def _cmp(obj1, obj2):
             st1 = sortable_title(obj1)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the categories are sorted exactly the same way as they are displayed in categories listing: Categories without `SortKey` are displayed last in the listing, following those with a `SortKey` value set. Same applies for services and other objects that come with the `SortKey` getter.

## Current behavior before PR

Categories **without** a value set for `SortKey` field are displayed first

## Desired behavior after PR is merged

Categories **with** a value set for `SortKey` field are displayed first

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
