### PR TITLE
Migrate ARReport to Dexterity

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #161 Migrate ARReport to Dexterity
 - #160 Fix categories without SortKey are displayed first
 - #159 Fix [+- ] symbol is displayed when uncertainty does not apply
 - #157 Fix custom scripts not rendered in final PDF

--- a/src/senaite/impress/storage.py
+++ b/src/senaite/impress/storage.py
@@ -22,6 +22,7 @@ from operator import methodcaller
 
 import transaction
 from bika.lims import api
+from plone.namedfile.file import NamedBlobFile
 from senaite.impress import logger
 from senaite.impress.decorators import synchronized
 from senaite.impress.interfaces import IPdfReportStorage
@@ -115,15 +116,28 @@ class PdfReportStorageAdapter(object):
         # Manually update the view on the database to avoid conflict errors
         parent._p_jar.sync()
 
-        # Create the report object
+        # Convert PDF binary data to NamedBlobFile
+        pdf_filename = "{}.pdf".format(parent_id)
+        pdf_blob = NamedBlobFile(
+            data=pdf,
+            filename=api.safe_unicode(pdf_filename),
+            contentType="application/pdf"
+        )
+
+        # Create the report object - metadata is now a plain dict (not DataGridField)
+        # NOTE: Don't pass UIDReferenceFields to api.create() as kwargs
+        # because they won't trigger backreference creation
         report = api.create(
             parent,
             "ResultsReport",
-            analysis_request=api.get_uid(parent),
-            pdf=pdf,
+            pdf=pdf_blob,
             html=html,
-            contained_analysis_requests=uids,
-            metadata=metadata)
+            metadata=metadata if metadata else {})
+
+        # Set UIDReferenceFields using mutators to create backreferences
+        report.setSample(api.get_uid(parent))
+        if uids:
+            report.setContainedSamples(uids)
 
         logger.info("Create Report for {} [DONE]".format(parent_id))
 

--- a/src/senaite/impress/storage.py
+++ b/src/senaite/impress/storage.py
@@ -80,8 +80,19 @@ class PdfReportStorageAdapter(object):
         # generate the reports
         reports = []
         for obj in objs:
-            report = self.create_report(obj, pdf, html, uids, metadata)
-            reports.append(report)
+            # Create savepoint before each report for rollback capability
+            sp = transaction.savepoint()
+            try:
+                report = self.create_report(obj, pdf, html, uids, metadata)
+                reports.append(report)
+            except Exception as e:
+                logger.error("Failed to create report for {}: {}".format(
+                    api.get_id(obj), str(e)))
+                sp.rollback()
+                raise
+
+        # Commit all reports in a single transaction
+        transaction.commit()
 
         return reports
 
@@ -90,10 +101,12 @@ class PdfReportStorageAdapter(object):
         """Create a new report object
 
         NOTE: We limit the creation of reports to 1 to avoid conflict errors on
-              simultaneous publication.
+              simultaneous publication. The transaction is committed once for
+              all reports in the store() method using savepoints for rollback
+              capability.
 
         :param parent: parent object where to create the report inside
-        :returns: ARReport
+        :returns: ResultsReport
         """
 
         parent_id = api.get_id(parent)
@@ -105,15 +118,12 @@ class PdfReportStorageAdapter(object):
         # Create the report object
         report = api.create(
             parent,
-            "ARReport",
-            AnalysisRequest=api.get_uid(parent),
-            Pdf=pdf,
-            Html=html,
-            ContainedAnalysisRequests=uids,
-            Metadata=metadata)
-
-        # Commit the changes
-        transaction.commit()
+            "ResultsReport",
+            analysis_request=api.get_uid(parent),
+            pdf=pdf,
+            html=html,
+            contained_analysis_requests=uids,
+            metadata=metadata)
 
         logger.info("Create Report for {} [DONE]".format(parent_id))
 

--- a/src/senaite/impress/storage.py
+++ b/src/senaite/impress/storage.py
@@ -124,20 +124,18 @@ class PdfReportStorageAdapter(object):
             contentType="application/pdf"
         )
 
-        # Create the report object - metadata is now a plain dict (not DataGridField)
-        # NOTE: Don't pass UIDReferenceFields to api.create() as kwargs
-        # because they won't trigger backreference creation
+        # Create the report object
+        # Field setters are called automatically by api.create(), including
+        # UIDReferenceField.set() which creates backreferences via event
+        # handler
         report = api.create(
             parent,
             "ResultsReport",
+            sample=api.get_uid(parent),
+            contained_samples=uids if uids else [],
             pdf=pdf_blob,
             html=html,
             metadata=metadata if metadata else {})
-
-        # Set UIDReferenceFields using mutators to create backreferences
-        report.setSample(api.get_uid(parent))
-        if uids:
-            report.setContainedSamples(uids)
 
         logger.info("Create Report for {} [DONE]".format(parent_id))
 

--- a/src/senaite/impress/storage.py
+++ b/src/senaite/impress/storage.py
@@ -134,7 +134,6 @@ class PdfReportStorageAdapter(object):
             sample=api.get_uid(parent),
             contained_samples=uids if uids else [],
             pdf=pdf_blob,
-            html=html,
             metadata=metadata if metadata else {})
 
         logger.info("Create Report for {} [DONE]".format(parent_id))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Compatibility with https://github.com/senaite/senaite.core/pull/2831

Furthermore, it improves the report storage by using transaction savepoints instead of full commits

## Current behavior before PR

`ARReport` contents are created when storing samples

## Desired behavior after PR is merged

`ResultsReport` contents are created when storing samples


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
