### PR TITLE
Fix rendering Error for Batch Labels

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #162 Fix rendering Error for Batch Labels
 - #161 Migrate ARReport to Dexterity
 - #160 Fix categories without SortKey are displayed first
 - #159 Fix [+- ] symbol is displayed when uncertainty does not apply

--- a/src/senaite/impress/analysisrequest/templates/summary.pt
+++ b/src/senaite/impress/analysisrequest/templates/summary.pt
@@ -89,7 +89,7 @@
         </tr>
         <tr tal:condition="python: batch and batch.BatchLabels">
           <td class="label" i18n:translate="">Batch Labels</td>
-          <td tal:content="structure python:', '.join(batch.BatchLabels)"></td>
+          <td tal:content="structure python:', '.join(map(lambda x: x.Title(), batch.BatchLabels))"></td>
         </tr>
       </table>
     </div>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a rendering error when a sample is assigned to a batch with batch labels.
<img width="1085" height="1052" alt="SCR-20260305-lozh" src="https://github.com/user-attachments/assets/b5cd7a77-63c2-4e3a-af41-204cfcf08de3" />


## Current behavior before PR

Error occurs:

```
Error: sequence item 0: expected string, SuperModel found

 - Expression: "python:', '.join(batch.BatchLabels)"
 - Filename:   ... src/senaite/impress/analysisrequest/templates/summary.pt
 - Location:   (line 92: col 37)
 - Source:     ... tent="structure python:', '.join(batch.BatchLabels)"></td>
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "python:view.render_summary(context, **options)"
 - Filename:   ... ss/src/senaite/impress/templates/reports/MultiDefault.pt
 - Location:   (line 22: col 28)
 - Source:     ... structure python:view.render_summary(context, **options)" />
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  publication_specification: ''
               request: <WSGIRequest, URL=http://localhost:8080/senaite/samples/ajax_publish/render_reports>
               attrs: {}
               container: <PloneSite at /senaite>
               specification: ''
               reporter: {'username': 'admin', 'fullname': '', 'userid': u'admin', 'email': '', 'roles': ['Manager', 'Authenticated']}
               traverse_subpath: []
               template: <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x10d7de408>
               translate: <function translate at 0x114beb438>
               spec: ''
               repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x1144454f8>
               views: <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x10e94f8c8>
               args: (<PloneSite at /senaite>,)
               here: <PloneSite at /senaite>
               user: <PropertiedUser 'admin'>
               nothing: None
               default: <DEFAULT>
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x109345508>
               batch: <SuperModel:UID(675c054bcfc345c48e3567217655aa0a)>
               client: <SuperModel:UID(8cc57720f09e490fb5c93ea777976f88)>
               loop: {}
               context: <PloneSite at /senaite>
               collection: [<SuperModel:UID(b30bdb4786d24d8b8e492f3f8faf0dfe)>]
               model: <SuperModel:UID(b30bdb4786d24d8b8e492f3f8faf0dfe)>
               view: <senaite.impress.analysisrequest.reportview.MultiReportView object at 0x114eb3c48>
               root: <Application at >
               options: {'page_width': 210.0, 'name': 'DIN A4', 'format': 'A4', 'content_height': 270.0, 'margin_right': 15.0, 'content_width': 180.0, 'margin_top': 12.0, 'margin_left': 15.0, 'report_options': {}, 'margin_bottom': 15.0, 'page_height': 297.0, 'orientation': u'portrait'}
               target_language: None
```

## Desired behavior after PR is merged

Batch labels are rendered correctly

<img width="717" height="193" alt="SCR-20260305-lnxq" src="https://github.com/user-attachments/assets/60e5a395-004f-47cd-a685-849bf9d732e7" />

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
