### PR TITLE
Resolve Laboratory from setup after DX migration in senaite.core

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #166 Resolve Laboratory from `setup` after DX migration in senaite.core
 - #164 Allow to define custom paperformats per template
 - #165 Fix attachment lookup with stale catalog brains in report
 - #163 Allow custom report logo upload via control panel

--- a/src/senaite/impress/actions/providers.py
+++ b/src/senaite/impress/actions/providers.py
@@ -96,7 +96,7 @@ class SendPDF(CustomAction):
     def laboratory(self):
         """Laboratory object from the LIMS setup
         """
-        return api.get_setup().laboratory
+        return api.get_senaite_setup().laboratory
 
     def is_sample(self, obj):
         """Check if the given object is a sample

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -147,7 +147,9 @@ class ReportView(Base):
     @property
     @returns_super_model
     def laboratory(self):
-        return self.setup.laboratory
+        # Laboratory was migrated to Dexterity in senaite.core 2.7 and
+        # now lives under `portal.setup` instead of `portal.bika_setup`.
+        return api.get_senaite_setup().laboratory
 
     @property
     def current_user(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Companion PR to senaite/senaite.core#2810, which migrates the
`Laboratory` content type to Dexterity and moves the singleton from
the legacy AT BikaSetup tool (`portal.bika_setup`) to the SENAITE DX
setup container (`portal.setup`).

After the core upgrade step runs, `portal.bika_setup.laboratory` no
longer exists, so any code path that reaches the laboratory through
`bika_setup` raises `AttributeError: laboratory`. In senaite.impress
this affects two places:

- `analysisrequest/reportview.py` — `view.laboratory` is consumed by
  every report template (e.g. footers, signature blocks). Republish
  fails with `Error: laboratory` on `view.get_managers()` /
  `view.render_signatures(...)`.
- `actions/providers.py` — `SendPDF.laboratory` is used to look up the
  sender email when mailing reports.

## Current behavior before PR

Both properties resolve the laboratory via the deprecated
`api.get_setup()` / `view.setup` path, which returns
`portal.bika_setup`. After core#2810 is merged and the upgrade step
has run, the laboratory is no longer there and report rendering /
PDF mail sending fail.

## Desired behavior after PR is merged

Both properties resolve the laboratory via `api.get_senaite_setup()`,
which returns `portal.setup` — the new DX container that owns the
migrated `Laboratory` object. Report rendering and PDF mailing keep
working after the core 2.7 upgrade step.

This change is backward-compatible: `api.get_senaite_setup()` already
exists in senaite.core 2.x prior to the migration; only the location
of the laboratory child object changes.

**Merge order:** this PR should be merged together with (or right
after) senaite/senaite.core#2810.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html