### PR TITLE
Fix accreditation body logo rendering after Laboratory DX migration

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #167 Fix accreditation body logo rendering after Laboratory DX migration
 - #166 Resolve Laboratory from `setup` after DX migration in senaite.core
 - #164 Allow to define custom paperformats per template
 - #165 Fix attachment lookup with stale catalog brains in report

--- a/src/senaite/impress/analysisrequest/reportview.py
+++ b/src/senaite/impress/analysisrequest/reportview.py
@@ -151,6 +151,21 @@ class ReportView(Base):
         # now lives under `portal.setup` instead of `portal.bika_setup`.
         return api.get_senaite_setup().laboratory
 
+    def get_accreditation_logo_url(self):
+        """Returns the URL of the laboratory's accreditation body logo
+
+        The laboratory was migrated to Dexterity in senaite.core 2.7, so the
+        logo is a `NamedBlobImage` served through the standard `@@images`
+        view instead of an Archetypes image with an `absolute_url`.
+
+        :returns: the accreditation logo URL, or None if no logo is set
+        """
+        laboratory = api.get_senaite_setup().laboratory
+        if not laboratory.getAccreditationBodyLogo():
+            return None
+        return "{}/@@images/accreditation_body_logo".format(
+            api.get_url(laboratory))
+
     @property
     def current_user(self):
         user = api.get_current_user()

--- a/src/senaite/impress/analysisrequest/templates/info.pt
+++ b/src/senaite/impress/analysisrequest/templates/info.pt
@@ -82,15 +82,15 @@
           <td>
             <div class="accreditation-logo text-left"
                  tal:define="accredited laboratory/LaboratoryAccredited;
-                        accreditation_logo laboratory/AccreditationBodyLogo"
+                        accreditation_logo_url python:view.get_accreditation_logo_url()"
                  tal:condition="accredited">
               <img class="img-fluid"
                    style="max-width:200px;"
-                   tal:condition="accreditation_logo"
-                   tal:attributes="src accreditation_logo/absolute_url"/>
+                   tal:condition="accreditation_logo_url"
+                   tal:attributes="src accreditation_logo_url"/>
               <img class="img-fluid"
                    style="max-width:200px;"
-                   tal:condition="not:accreditation_logo"
+                   tal:condition="not:accreditation_logo_url"
                    tal:attributes="src python:view.get_resource_url('AccreditationBodyLogo.png', prefix='bika.lims.images' )"/>
             </div>
             <div class="text-right">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

senaite.core 2.7 migrated the `Laboratory` content type to Dexterity, so its accreditation body logo is now a `plone.namedfile.NamedBlobImage` instead of an Archetypes image. The sample info template still built the image `src` via `accreditation_logo/absolute_url`, which a `NamedBlobImage` does not provide.

## Current behavior before PR

Rendering the default report (`senaite.impress:Default.pt`) for an accredited laboratory that has an accreditation logo uploaded raises:

```
Error: (<plone.namedfile.file.NamedBlobImage object ...>, 'absolute_url')
 - Expression: "accreditation_logo/absolute_url"
 - Filename:   senaite/impress/analysisrequest/templates/info.pt (line 90)
```

## Desired behavior after PR is merged

The accreditation logo renders correctly. A new `get_accreditation_logo_url` helper on the report view serves the `NamedBlobImage` through the standard `@@images` view (`{laboratory_url}/@@images/accreditation_body_logo`), and `info.pt` uses it. The existing fallback to the bundled `AccreditationBodyLogo.png` is kept for laboratories without a custom logo.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html