### PR TITLE
Fix local detection of Dexterity @@images resources in Impress url_fetcher

### DIFF
--- a/src/senaite/impress/publisher.py
+++ b/src/senaite/impress/publisher.py
@@ -145,7 +145,12 @@ class Publisher(object):
 
     @synchronized(max_connections=2)
     def url_fetcher(self, url):
-        """Fetches internal URLs by path and not via an external request.
+        """Fetch internal URLs by path instead of via an external request.
+
+        Browser views such as ``@@images`` handle parts of their paths
+        dynamically. Therefore, the owning content object is used when checking
+        whether an image resource is local, while the complete path is passed to
+        the authenticated subrequest.
 
         N.B. Multiple calls to this method might exhaust the available threads
              of the server, which causes a hanging instance.
@@ -156,14 +161,19 @@ class Publisher(object):
 
         logger.info("Fetching URL '{}' for WeasyPrint".format(url))
 
-        # get the pyhsical path from the URL
         request = api.get_request()
+        portal = api.get_portal()
+
         host = request.get_header("HOST")
         path = "/".join(request.physicalPathFromURL(url))
 
-        # fetch the object by sub-request
-        portal = api.get_portal()
-        context = portal.restrictedTraverse(path, None)
+        # The final field segment after @@images is handled dynamically by the
+        # images browser view and might not resolve with restrictedTraverse.
+        traverse_path = path
+        if "/@@images/" in path:
+            traverse_path = path.split("/@@images/", 1)[0]
+
+        context = portal.restrictedTraverse(traverse_path, None)
 
         if context is None or (host and host not in url):
             logger.info("External URL, delegate to default URL fetcher...")
@@ -171,22 +181,24 @@ class Publisher(object):
 
         logger.info("Local URL, fetching data by path '{}'".format(path))
 
-        # get the data via an authenticated subrequest
+        # Fetch the local resource through an authenticated Zope subrequest.
         response = subrequest(path)
 
-        # Prepare the return data as required by WeasyPrint
         string = response.getBody()
-        filename = url.split("/")[-1]
-        mime_type = mimetypes.guess_type(url)[0]
-        redirected_url = url
+        filename = url.rstrip("/").split("/")[-1]
+
+        # Dynamic URLs such as @@images/accreditation_body_logo have no file
+        # extension, so prefer the response's actual Content-Type.
+        mime_type = response.getHeader("Content-Type")
+        if not mime_type:
+            mime_type = mimetypes.guess_type(url)[0]
 
         return {
             "string": string,
             "filename": filename,
             "mime_type": mime_type,
-            "redirected_url": redirected_url,
+            "redirected_url": url,
         }
-
     def write_png(self, html, resolution=96):
         """Write a PNG from the given HTML
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.impress/issues/168
Fixes the detection of local Dexterity image resources when rendering PDFs.

Browser views such as `@@images` resolve the image field segment dynamically,
therefore traversing the complete image URL may return `None` even though the
resource belongs to the current Plone site.

This causes the publisher to incorrectly delegate image loading to
`default_url_fetcher()`, resulting in external HTTP requests and connection
timeouts.
## Current behavior before PR
The image is classified as an external resource and fetched with
default_url_fetcher().
Typical log output:
context=None
External URL, delegate to default URL fetcher...

The PDF generation waits for the external connection timeout before continuing.

## Desired behavior after PR is merged

Dexterity @@images resources should be treated as local resources and fetched
through an authenticated subrequest, just like other Plone resources.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
