### PR TITLE
Extend senaite.core's buildout.base.cfg instead of duplicating it

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,101 +1,21 @@
 [buildout]
-index = https://pypi.org/simple/
-extends = https://dist.plone.org/release/5.2-latest/versions.cfg
-find-links =
-    https://dist.plone.org/release/5.2-latest/
-    https://dist.plone.org/thirdparty/
+extends = https://raw.githubusercontent.com/senaite/senaite.core/2.x/buildout.base.cfg
+package-name = senaite.impress
 
-parts =
-    instance
-    test
-    omelette
-    i18ndude
-    zopepy
+parts +=
     update_translations
-    write_code_headers
 
-eggs =
+# Auto-checkout all sources but senaite.impress
+auto-checkout =
     senaite.core
     senaite.app.listing
     senaite.app.spotlight
     senaite.app.supermodel
-    senaite.impress
     senaite.jsonapi
     senaite.lims
-    plone.reload
-
-extensions = mr.developer
-
-package-name = senaite.impress
-
-versions = versions
-show-picked-versions = true
-
-plone-user = admin:admin
-
-develop = .
-sources = sources
-auto-checkout = *
-
-[sources]
-senaite.core = git https://github.com/senaite/senaite.core.git pushurl=git@github.com:senaite/senaite.core.git branch=2.x
-senaite.app.listing = git https://github.com/senaite/senaite.app.listing.git pushurl=git@github.com:senaite/senaite.app.listing.git branch=2.x
-senaite.app.spotlight = git https://github.com/senaite/senaite.app.spotlight.git pushurl=git@github.com:senaite/senaite.app.spotlight.git branch=2.x
-senaite.app.supermodel = git https://github.com/senaite/senaite.app.supermodel.git pushurl=git@github.com:senaite/senaite.app.supermodel.git branch=2.x
-senaite.lims = git https://github.com/senaite/senaite.lims.git pushurl=git@github.com:senaite/senaite.lims.git branch=2.x
-senaite.jsonapi = git https://github.com/senaite/senaite.jsonapi.git pushurl=git@github.com:senaite/senaite.jsonapi.git branch=2.x
-
-[instance]
-recipe = plone.recipe.zope2instance
-http-address = 127.0.0.1:8080
-user = ${buildout:plone-user}
-wsgi = on
-eggs =
-    Plone[archetypes]
-    plone.app.upgrade
-    ${buildout:package-name}
-    ${buildout:eggs}
-deprecation-warnings = on
-environment-vars =
-    zope_i18n_compile_mo_files true
-resources = ${buildout:directory}/resources
-zcml =
-
-[i18ndude]
-unzip = true
-recipe = zc.recipe.egg
-eggs = i18ndude
 
 [update_translations]
 recipe = collective.recipe.template
 output = ${buildout:directory}/bin/update_translations
 input = ${buildout:directory}/templates/update_translations.in
 mode = 755
-
-[write_code_headers]
-recipe = collective.recipe.template
-output = ${buildout:directory}/bin/write_code_headers
-input = ${buildout:directory}/templates/write_code_headers.py.in
-mode = 755
-
-[test]
-recipe = zc.recipe.testrunner
-defaults = ['--auto-color', '--auto-progress']
-eggs =
-    senaite.impress [test]
-
-[omelette]
-recipe = collective.recipe.omelette
-eggs = ${buildout:eggs}
-
-[zopepy]
-recipe = zc.recipe.egg
-eggs = ${instance:eggs}
-interpreter = zopepy
-scripts = zopepy
-
-[versions]
-# versions need to match the versions in requirements.txt
-# https://github.com/collective/buildout.plonetest/#testing-in-travis-ci-with-multiple-versions-of-plone-and-python
-setuptools = 44.1.1
-zc.buildout = 2.13.3

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #170 Extend senaite.core's buildout.base.cfg instead of duplicating it
 - #167 Fix accreditation body logo rendering after Laboratory DX migration
 - #166 Resolve Laboratory from `setup` after DX migration in senaite.core
 - #164 Allow to define custom paperformats per template


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`plone.jsonapi.core` 0.8.0 is published on PyPI under the PEP 625 normalized sdist filename `plone_jsonapi_core-0.8.0.tar.gz`, which the `setuptools` 44.1.1 resolver we are pinned to on Python 2.7 cannot match against the dotted `plone.jsonapi.core` requirement. The fix (a `find-links` entry for the legacy dotted-name sdist attached to the GitHub release, plus an explicit version pin) was applied to `senaite.core`'s `buildout.base.cfg`, so every add-on that extends that file inherits it automatically.

This package did not: it carried its own ~100 line copy of the base buildout, so the fix would have had to be duplicated here by hand — and the same would be true of every future change to the shared development buildout.

Rather than copy the two lines, this PR removes the duplication and extends `senaite.core`'s `buildout.base.cfg`, matching what `senaite.patient`, `senaite.jsonapi`, `senaite.abx`, `senaite.ast`, `senaite.storage` and the other add-ons already do.

Companion PRs do the same for `senaite.app.listing`, `senaite.app.spotlight`, `senaite.app.supermodel` and `senaite.lims`, the remaining packages that still carried their own copy.

## Current behavior before PR

`buildout.cfg` is a 101 line standalone config that re-declares `index`, `find-links`, `parts`, `eggs`, `[sources]`, `[instance]`, `[i18ndude]`, `[test]`, `[omelette]`, `[zopepy]`, `[write_code_headers]` and `[versions]`, all near-identical to `senaite.core`'s `buildout.base.cfg` but free to drift from it. It does not pick up the `plone.jsonapi.core` 0.8.0 fix.

## Desired behavior after PR is merged

`buildout.cfg` is reduced to 21 lines: the `extends` of `senaite.core`'s `buildout.base.cfg`, `package-name`, an `auto-checkout` list that excludes this package (which is supplied by `develop = .`), and the `update_translations` part.

`update_translations` is kept local rather than inherited, because the base buildout does not provide it and the script is package-specific: it drives i18ndude and Transifex over `src/senaite/impress/locales`, which currently holds 10 languages. `senaite.core` keeps its own `update_translations` part in `buildout.cfg` for the same reason, so this matches the established pattern.

The `plone.jsonapi.core` find-links entry and `= 0.8.0` pin are inherited, and future base-buildout changes arrive without a PR here.

Inheriting the base rather than the local copy also changes the following development-only settings. None affect the shipped package:

- `[instance] wsgi` becomes `off`, so `bin/instance` runs under ZServer instead of waitress — the same as `senaite.core` and the other add-ons.
- `[instance] eggs` uses `Plone` rather than `Plone[archetypes]`. Nothing in `src/` imports `Products.Archetypes`, and `senaite.core` pulls `Products.ATContentTypes` in regardless.
- `[instance] resources` is dropped. It pointed at a `resources/` directory that does not exist in this repo, so the recipe was creating an empty one and registering an empty ZCML resource directory.
- `[versions]` no longer pins `setuptools = 44.1.1` / `zc.buildout = 2.13.3` explicitly; `requirements.txt` still installs exactly those versions.
- `[sources]` loses the `pushurl=git@github.com:...` entries, so pushing from a checked-out `src/` sibling uses HTTPS. If we want these back, they belong in `buildout.base.cfg` for all add-ons rather than re-duplicated here.


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
